### PR TITLE
Add tutWait and tutSetCameraTarget

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -1,7 +1,7 @@
 import { reloadable } from "./lib/tstl-utils";
 import { findAllPlayers } from "./util";
 import { tutFork, tutSeq } from "./TutorialGraph/Core";
-import { tutGoToLocation, tutSpawnAndKillUnit } from "./TutorialGraph/Steps";
+import { tutGoToLocation, tutSetCameraTarget, tutSpawnAndKillUnit, tutWait } from "./TutorialGraph/Steps";
 
 declare global {
     interface CDOTAGamerules {
@@ -78,10 +78,20 @@ export class GameMode {
 
         // Example tutorial graph.
         // Sequence:
-        // 1. Wait for hero to go to location (0, 0, 0)
-        // 2. Spawn hero at (1000, 0, 0) and wait until it dies
-        // 3. Spawn two heroes at (1500, 0, 0) and wait for both of them to die
+        // 1. Focus camera on dire ancient
+        // 2. Focus camera on dragon knight (our hero hopefully)
+        // 3. Free camera
+        // 4. Wait for hero to go to location (0, 0, 0)
+        // 5. Spawn hero at (1000, 0, 0) and wait until it dies
+        // 6. Spawn two heroes at (1500, 0, 0) and wait for both of them to die
         const tutorial = tutSeq(
+            tutWait(3),
+            tutSetCameraTarget(Entities.FindAllByName("dota_badguys_fort")[0]),
+            tutWait(5),
+            tutSetCameraTarget(Entities.FindAllByName("npc_dota_hero_dragon_knight")[0]),
+            tutWait(2),
+            tutSetCameraTarget(undefined),
+            tutWait(2),
             tutGoToLocation(Vector(0, 0, 0)),
             tutSpawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0)),
             tutFork(

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -1,3 +1,4 @@
+import { findAllPlayers } from "../util"
 import { tutStep } from "./Core"
 
 const isHeroNearby = (location: Vector, radius: number) => FindUnitsInRadius(
@@ -48,5 +49,30 @@ export const tutSpawnAndKillUnit = (unitName: string, spawnLocation: Vector) => 
         }
 
         checkIsDead()
+    }, () => { })
+}
+
+/**
+ * Waits for an amount of time until completion
+ * @param waitSeconds Time to wait before completion
+ */
+export const tutWait = (waitSeconds: number) => {
+    return tutStep((context, complete) => {
+        Timers.CreateTimer(waitSeconds, () => complete())
+    }, () => { })
+}
+
+/**
+ * Focuses the camera to a target or frees it.
+ * @param target Target to focus the camera on. Can be undefined for freeing the camera.
+ */
+export const tutSetCameraTarget = (target: CBaseEntity | undefined) => {
+    return tutStep((context, complete) => {
+        const playerIds = findAllPlayers()
+
+        // Focus all cameras on the target
+        playerIds.forEach(playerId => PlayerResource.SetCameraTarget(playerId, target))
+
+        complete()
     }, () => { })
 }


### PR DESCRIPTION
More primitives for the tutorial graph:
- `tutWait` waits for an amount of seconds
- `tutSetCameraTarget` sets (or clears) the camera target

The latter will be used for example in https://github.com/ModDota/dota-tutorial/issues/9 where the camera target is set to the enemy ancient.

Although maybe we'll want to do the camera stuff with client-side functions instead? Eg. I don't know if it's possible here to reset the camera to its original location (although of course we could just set the camera location to our hero).