### PR TITLE
Add tutorial sections

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -1,7 +1,7 @@
 import { reloadable } from "./lib/tstl-utils";
 import { findAllPlayers } from "./util";
-import { tutFork, tutSeq } from "./TutorialGraph/Core";
-import { tutGoToLocation, tutSetCameraTarget, tutSpawnAndKillUnit, tutWait } from "./TutorialGraph/Steps";
+import * as tut from "./Tutorial/Core"
+import { section0 } from "./Sections/index"
 
 declare global {
     interface CDOTAGamerules {
@@ -76,31 +76,9 @@ export class GameMode {
     private StartGame(): void {
         print("Game starting!");
 
-        // Example tutorial graph.
-        // Sequence:
-        // 1. Focus camera on dire ancient
-        // 2. Focus camera on dragon knight (our hero hopefully)
-        // 3. Free camera
-        // 4. Wait for hero to go to location (0, 0, 0)
-        // 5. Spawn hero at (1000, 0, 0) and wait until it dies
-        // 6. Spawn two heroes at (1500, 0, 0) and wait for both of them to die
-        const tutorial = tutSeq(
-            tutWait(3),
-            tutSetCameraTarget(Entities.FindAllByName("dota_badguys_fort")[0]),
-            tutWait(5),
-            tutSetCameraTarget(Entities.FindAllByName("npc_dota_hero_dragon_knight")[0]),
-            tutWait(2),
-            tutSetCameraTarget(undefined),
-            tutWait(2),
-            tutGoToLocation(Vector(0, 0, 0)),
-            tutSpawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0)),
-            tutFork(
-                tutSpawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0)),
-                tutSpawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0))
-            )
-        )
-
-        tutorial.start({}, () => print("Tutorial was completed"))
+        const tutorial = tut.createTutorial(section0)
+        tut.start(tutorial)
+        // To start from specific section by index: tut.start(tutorial, 5)
     }
 
     // Called on script_reload

--- a/game/scripts/vscripts/Sections/Section0.ts
+++ b/game/scripts/vscripts/Sections/Section0.ts
@@ -1,0 +1,40 @@
+import * as tg from "../TutorialGraph/index"
+import * as tut from "../Tutorial/Core"
+
+export const section0 = tut.createSection("Section 0",
+    complete => {
+        print("Started section 0")
+
+        // Example tg.orial graph.
+        // Sequence:
+        // 1. Focus camera on dire ancient
+        // 2. Focus camera on dragon knight (our hero hopefully)
+        // 3. Free camera
+        // 4. Wait for hero to go to location (0, 0, 0)
+        // 5. Spawn hero at (1000, 0, 0) and wait until it dies
+        // 6. Spawn two heroes at (1500, 0, 0) and wait for both of them to die
+        const graph = tg.seq(
+            tg.wait(3),
+            tg.setCameraTarget(Entities.FindAllByName("dota_badguys_fort")[0]),
+            tg.wait(5),
+            tg.setCameraTarget(Entities.FindAllByName("npc_dota_hero_dragon_knight")[0]),
+            tg.wait(2),
+            tg.setCameraTarget(undefined),
+            tg.wait(2),
+            tg.goToLocation(Vector(0, 0, 0)),
+            tg.spawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0)),
+            tg.fork(
+                tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0)),
+                tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0))
+            )
+        )
+
+        graph.start({}, () => {
+            print("Section 0 was completed")
+            complete()
+        })
+    },
+    () => {
+        // TODO: Make sure DK exists at spawn and other stuff (yea stuff...)
+    }
+)

--- a/game/scripts/vscripts/Sections/index.ts
+++ b/game/scripts/vscripts/Sections/index.ts
@@ -1,0 +1,1 @@
+export * from "./Section0"

--- a/game/scripts/vscripts/Tutorial/Core.ts
+++ b/game/scripts/vscripts/Tutorial/Core.ts
@@ -1,0 +1,43 @@
+export type Section = {
+    name: string
+    start: (complete: () => void) => void
+    setupState: () => void
+}
+
+export const createSection = (name: string, start: (complete: () => void) => void, setupState: () => void): Section => {
+    return { name, start, setupState }
+}
+
+export type Tutorial = {
+    sections: Section[]
+}
+
+export const createTutorial = (...sections: Section[]): Tutorial => {
+    return { sections }
+}
+
+export const start = (tutorial: Tutorial, fromSection?: number) => {
+    const { sections } = tutorial
+
+    // Allow starting from a specific section. If one was passed we want
+    // to also setup the state for it. Otherwise we just start from the beginning
+    // and assume we don't need any setup.
+    if (fromSection === undefined) {
+        fromSection = 0
+    } else {
+        sections[fromSection].setupState()
+    }
+
+    const startSection = (i: number) => {
+        const section = sections[i]
+
+        if (i + 1 >= sections.length) {
+            section.start(() => print("Done with all tutorial sections"))
+            // TODO: End the game? Call some callback?
+        } else {
+            section.start(() => startSection(i + 1))
+        }
+    }
+
+    startSection(fromSection)
+}

--- a/game/scripts/vscripts/TutorialGraph/Core.ts
+++ b/game/scripts/vscripts/TutorialGraph/Core.ts
@@ -14,30 +14,24 @@ export type TutorialStep = {
      * Called when the step is started. Should call complete when the step is done. Can use context to share data with other steps.
      */
     start: (context: TutorialContext, complete: () => void) => void
-
-    /**
-     * Called when the step is supposed to reset to its initial step.
-     */
-    reset: () => void
 }
 
 /**
- * Creates a tutorial step given the start and reset functions.
+ * Creates a tutorial step given the start function.
  * @param start Called when the step is started. Should call complete when the step is done. Can use context to share data with other steps.
- * @param reset Called when the step is supposed to reset to its initial state.
  */
-export const tutStep = (start: (context: TutorialContext, complete: () => void) => void, reset: () => void): TutorialStep => {
-    return { start, reset }
+export const step = (start: (context: TutorialContext, complete: () => void) => void): TutorialStep => {
+    return { start }
 }
 
 /**
  * Creates a tutorial step that waits for steps to complete in parallel before completing itself.
  * @param steps List of tutorial steps to wrap in parallel.
  */
-export const tutFork = (...steps: TutorialStep[]): TutorialStep => {
+export const fork = (...steps: TutorialStep[]): TutorialStep => {
     const stepsCompleted = steps.map(s => false)
 
-    return tutStep((context, onComplete) => {
+    return step((context, onComplete) => {
         // Once all steps are completed, complete ourselves
         for (let i = 0; i < steps.length; i++) {
             const stepIndex = i
@@ -48,15 +42,15 @@ export const tutFork = (...steps: TutorialStep[]): TutorialStep => {
                 }
             })
         }
-    }, () => steps.forEach(step => step.reset()))
+    })
 }
 
 /**
  * Creates a tutorial step that executes individual steps one after another. The step completes when the final step was completed.
  * @param steps List of tutorial steps to wrap sequentially.
  */
-export const tutSeq = (...steps: TutorialStep[]): TutorialStep => {
-    return tutStep((context, onComplete) => {
+export const seq = (...steps: TutorialStep[]): TutorialStep => {
+    return step((context, onComplete) => {
         const startStep = (i: number) => {
             const step = steps[i]
 
@@ -68,5 +62,5 @@ export const tutSeq = (...steps: TutorialStep[]): TutorialStep => {
         }
 
         startStep(0)
-    }, () => steps.forEach(step => step.reset()))
+    })
 }

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -1,5 +1,5 @@
 import { findAllPlayers } from "../util"
-import { tutStep } from "./Core"
+import { step } from "./Core"
 
 const isHeroNearby = (location: Vector, radius: number) => FindUnitsInRadius(
     DOTATeam_t.DOTA_TEAM_GOODGUYS, location, undefined, radius,
@@ -13,8 +13,8 @@ const isHeroNearby = (location: Vector, radius: number) => FindUnitsInRadius(
  * Creates a tutorial step that waits for a hero to go to a location.
  * @param location Target location
  */
-export const tutGoToLocation = (location: Vector) => {
-    return tutStep((context, complete) => {
+export const goToLocation = (location: Vector) => {
+    return step((context, complete) => {
         Tutorial.CreateLocationTask(location)
 
         // Wait until a hero is at the goal location
@@ -27,7 +27,7 @@ export const tutGoToLocation = (location: Vector) => {
         }
 
         checkIsAtGoal()
-    }, () => { })
+    })
 }
 
 /**
@@ -35,8 +35,8 @@ export const tutGoToLocation = (location: Vector) => {
  * @param unitName Name of the unit to spawn.
  * @param spawnLocation Location to spawn the unit at.
  */
-export const tutSpawnAndKillUnit = (unitName: string, spawnLocation: Vector) => {
-    return tutStep((context, complete) => {
+export const spawnAndKillUnit = (unitName: string, spawnLocation: Vector) => {
+    return step((context, complete) => {
         const unit = CreateUnitByName(unitName, spawnLocation, true, undefined, undefined, DOTATeam_t.DOTA_TEAM_NEUTRALS)
 
         // Wait until the unit dies
@@ -49,30 +49,30 @@ export const tutSpawnAndKillUnit = (unitName: string, spawnLocation: Vector) => 
         }
 
         checkIsDead()
-    }, () => { })
+    })
 }
 
 /**
  * Waits for an amount of time until completion
  * @param waitSeconds Time to wait before completion
  */
-export const tutWait = (waitSeconds: number) => {
-    return tutStep((context, complete) => {
+export const wait = (waitSeconds: number) => {
+    return step((context, complete) => {
         Timers.CreateTimer(waitSeconds, () => complete())
-    }, () => { })
+    })
 }
 
 /**
  * Focuses the camera to a target or frees it.
  * @param target Target to focus the camera on. Can be undefined for freeing the camera.
  */
-export const tutSetCameraTarget = (target: CBaseEntity | undefined) => {
-    return tutStep((context, complete) => {
+export const setCameraTarget = (target: CBaseEntity | undefined) => {
+    return step((context, complete) => {
         const playerIds = findAllPlayers()
 
         // Focus all cameras on the target
         playerIds.forEach(playerId => PlayerResource.SetCameraTarget(playerId, target))
 
         complete()
-    }, () => { })
+    })
 }

--- a/game/scripts/vscripts/TutorialGraph/index.ts
+++ b/game/scripts/vscripts/TutorialGraph/index.ts
@@ -1,0 +1,2 @@
+export * from "./Core"
+export * from "./Steps"


### PR DESCRIPTION
We discussed using the tutorial graph system for the sections on discord. The conclusion was that we should probably not base everything on the tutorial graph system and make a broader and simpler section system instead.

Sections have a `start` function which do all the work for the section in normal code. The `start` function should call complete once its done. They also have a `setupState` function which should put the state into what the section needs it to be (might be tricky but we felt this was easier to create and to understand than having undo/skip for every single step). Tutorials are then just lists of sections and there is a function to start the tutorial either from scratch (without `setupState`) or from a specific section.

Some more things done in this PR:
- Removed the prefixes from the tutorial graph system functions as we can just import them with a namespace
- Moved the example graph into its own tutorial section
- Removed the `reset` function from the tutorial graph system as it isn't needed right now