### PR TITLE
Add stop and skip functionality

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -76,8 +76,16 @@ export class GameMode {
     private StartGame(): void {
         print("Game starting!");
 
-        const tutorial = tut.createTutorial(section0)
-        tut.start(tutorial)
+        const tutorial = new tut.Tutorial([section0, section0, section0])
+
+        print("Starting tutorial from scratch")
+        tutorial.start()
+
+        Timers.CreateTimer(5, () => {
+            print("Skipping tutorial to section with index 2")
+            tutorial.start(2)
+        })
+
         // To start from specific section by index: tut.start(tutorial, 5)
     }
 

--- a/game/scripts/vscripts/Sections/README.md
+++ b/game/scripts/vscripts/Sections/README.md
@@ -1,0 +1,10 @@
+# Sections
+Sections are contained parts of the tutorial. They are composed of 3 functions
+- `start`: Called when the section is supposed to start. Should contain most of the logic. Is passed a `complete` callback which should be called when the section is over.
+- `stop`: Called when we want the section to stop. Can also be called if the section wasn't even started. Should clean up any resources created in `start` and stop any timers.
+- `setupState`: Called before we go into this section if we didn't go into it the normal way (ie. when skipping to this section). Should set up anything needed for this section such as learning hero abilities.
+
+Sections can either be created by extending the abstract `Section` class and implementing those three functions or by creating the functions separately and passing them to `FunctionalSection` in the constructor.
+
+The tutorial graph system can be used to easily implement common behavior, especially async ones that require waiting (for a condition, for an amount of time, ...) between sequential steps. However it is not mandatory to
+use it and it is possible to implement sections completely without it if desired.

--- a/game/scripts/vscripts/Sections/Section0.ts
+++ b/game/scripts/vscripts/Sections/Section0.ts
@@ -1,40 +1,54 @@
 import * as tg from "../TutorialGraph/index"
 import * as tut from "../Tutorial/Core"
 
-export const section0 = tut.createSection("Section 0",
-    complete => {
-        print("Started section 0")
+let graph: tg.TutorialStep | undefined = undefined
+let graphContext: tg.TutorialContext | undefined = undefined
 
-        // Example tg.orial graph.
-        // Sequence:
-        // 1. Focus camera on dire ancient
-        // 2. Focus camera on dragon knight (our hero hopefully)
-        // 3. Free camera
-        // 4. Wait for hero to go to location (0, 0, 0)
-        // 5. Spawn hero at (1000, 0, 0) and wait until it dies
-        // 6. Spawn two heroes at (1500, 0, 0) and wait for both of them to die
-        const graph = tg.seq(
-            tg.wait(3),
-            tg.setCameraTarget(Entities.FindAllByName("dota_badguys_fort")[0]),
-            tg.wait(5),
-            tg.setCameraTarget(Entities.FindAllByName("npc_dota_hero_dragon_knight")[0]),
-            tg.wait(2),
-            tg.setCameraTarget(undefined),
-            tg.wait(2),
-            tg.goToLocation(Vector(0, 0, 0)),
-            tg.spawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0)),
-            tg.fork(
-                tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0)),
-                tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0))
-            )
+const start = (complete: () => void) => {
+    print("Started section 0")
+
+    // Example tutorial graph.
+    // Sequence:
+    // 1. Focus camera on dire ancient
+    // 2. Focus camera on dragon knight (our hero hopefully)
+    // 3. Free camera
+    // 4. Wait for hero to go to location (0, 0, 0)
+    // 5. Spawn hero at (1000, 0, 0) and wait until it dies
+    // 6. Spawn two heroes at (1500, 0, 0) and wait for both of them to die
+    graph = tg.seq(
+        tg.wait(3),
+        tg.setCameraTarget(Entities.FindAllByName("dota_badguys_fort")[0]),
+        tg.wait(5),
+        tg.setCameraTarget(Entities.FindAllByName("npc_dota_hero_dragon_knight")[0]),
+        tg.wait(2),
+        tg.setCameraTarget(undefined),
+        tg.wait(2),
+        tg.goToLocation(Vector(0, 0, 0)),
+        tg.spawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0)),
+        tg.fork(
+            tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0)),
+            tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0))
         )
+    )
 
-        graph.start({}, () => {
-            print("Section 0 was completed")
-            complete()
-        })
-    },
-    () => {
-        // TODO: Make sure DK exists at spawn and other stuff (yea stuff...)
+    graphContext = {}
+
+    graph.start(graphContext, () => {
+        print("Section 0 was completed")
+        complete()
+    })
+}
+
+const resetState = () => {
+    // TODO: Make sure DK exists at spawn and other stuff (yea stuff...)
+}
+
+const stop = () => {
+    if (graph) {
+        graph.stop(graphContext ?? {})
+        graph = undefined
+        graphContext = undefined
     }
-)
+}
+
+export const section0 = new tut.FunctionalSection("Section 0", start, resetState, stop)

--- a/game/scripts/vscripts/Tutorial/Core.ts
+++ b/game/scripts/vscripts/Tutorial/Core.ts
@@ -1,43 +1,114 @@
-export type Section = {
-    name: string
-    start: (complete: () => void) => void
-    setupState: () => void
-}
+/**
+ * Tutorial section that contains logic for a single section of the tutorial. Should also
+ * be able to handle setup and cleanup of its state.
+ */
+export abstract class Section {
+    /**
+     * Creates a section.
+     * @param name Name of the section.
+     */
+    constructor(public readonly name: string) {
 
-export const createSection = (name: string, start: (complete: () => void) => void, setupState: () => void): Section => {
-    return { name, start, setupState }
-}
-
-export type Tutorial = {
-    sections: Section[]
-}
-
-export const createTutorial = (...sections: Section[]): Tutorial => {
-    return { sections }
-}
-
-export const start = (tutorial: Tutorial, fromSection?: number) => {
-    const { sections } = tutorial
-
-    // Allow starting from a specific section. If one was passed we want
-    // to also setup the state for it. Otherwise we just start from the beginning
-    // and assume we don't need any setup.
-    if (fromSection === undefined) {
-        fromSection = 0
-    } else {
-        sections[fromSection].setupState()
     }
 
-    const startSection = (i: number) => {
-        const section = sections[i]
+    /**
+     * Called when the section should start. Should contain the main logic for the section. Should call complete when done.
+     */
+    public abstract start: (complete: () => void) => void
 
-        if (i + 1 >= sections.length) {
-            section.start(() => print("Done with all tutorial sections"))
-            // TODO: End the game? Call some callback?
-        } else {
-            section.start(() => startSection(i + 1))
+    /**
+     * Called when we want to set up the state for this section when skipping to it (ie. when the assumptions it makes about the preceding
+     * sections are possibly false such as a hero being alive).
+     */
+    public abstract setupState: () => void
+
+    /**
+     * Called when we want this section to stop. Should stop any progress as well as clean up any resources (eg. remove any spawned units or clean up timers).
+     */
+    public abstract stop: () => void
+}
+
+/**
+ * Functional implementation of section that gets start, setupState and stop passed on construction.
+ */
+export class FunctionalSection extends Section {
+    /**
+     * Creates a section given its functions.
+     * @param name Name of the section.
+     * @param start start function of the section. See Section.start.
+     * @param setupState setupState function of the section. See Section.setupState.
+     * @param stop stop function of the section. See Section.stop.
+     */
+    constructor(public readonly name: string,
+        public readonly start: (complete: () => void) => void,
+        public readonly setupState: () => void,
+        public readonly stop: () => void) {
+        super(name)
+    }
+}
+
+export class Tutorial {
+    private _currentSection: Section | undefined = undefined
+
+    /**
+     * Whether the tutorial is in progress and a section is currently started.
+     */
+    get isInProgress() {
+        return this._currentSection !== undefined
+    }
+
+    /**
+     * Current section in progress if any.
+     */
+    get currentSection() {
+        return this._currentSection
+    }
+
+    /**
+     * Creates a tutorial from its sections.
+     * @param sections Sections contained in the tutorial. Executed sequentially.
+     */
+    constructor(private readonly sections: Section[]) {
+
+    }
+
+    /**
+     * Starts the tutorial. Can be called while already started to stop the current section and start the new one.
+     * @param sectionIndex Section to start at. If not passed starts with the first section. If passed also calls setupState on that section before starting it.
+     */
+    public start(sectionIndex?: number) {
+        // Stop the current section to make sure any progress is stopped and cleaned up.
+        print("Stopping current section")
+        if (this.currentSection) {
+            this.currentSection.stop()
         }
-    }
 
-    startSection(fromSection)
+        // Allow starting from a specific section. If one was passed we want
+        // to also setup the state for it. Otherwise we just start from the beginning
+        // and assume we don't need any setup.
+        if (sectionIndex === undefined) {
+            sectionIndex = 0
+        } else {
+            this.sections[sectionIndex].setupState()
+        }
+
+        const startSection = (i: number) => {
+            this._currentSection = this.sections[i]
+            print("Starting section", i)
+
+            if (i + 1 >= this.sections.length) {
+                this._currentSection.start(() => {
+                    print("Done with all tutorial sections")
+                    this._currentSection = undefined
+                    // TODO: End the game? Call some callback?
+                })
+            } else {
+                this._currentSection.start(() => {
+                    startSection(i + 1)
+                })
+            }
+        }
+
+        startSection(sectionIndex)
+    }
 }

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -14,6 +14,8 @@ const isHeroNearby = (location: Vector, radius: number) => FindUnitsInRadius(
  * @param location Target location
  */
 export const goToLocation = (location: Vector) => {
+    let checkTimer: string | undefined = undefined
+
     return step((context, complete) => {
         Tutorial.CreateLocationTask(location)
 
@@ -22,11 +24,16 @@ export const goToLocation = (location: Vector) => {
             if (isHeroNearby(location, 200)) {
                 complete()
             } else {
-                Timers.CreateTimer(1, () => checkIsAtGoal())
+                checkTimer = Timers.CreateTimer(1, () => checkIsAtGoal())
             }
         }
 
         checkIsAtGoal()
+    }, context => {
+        if (checkTimer) {
+            Timers.RemoveTimer(checkTimer)
+            checkTimer = undefined
+        }
     })
 }
 
@@ -36,19 +43,32 @@ export const goToLocation = (location: Vector) => {
  * @param spawnLocation Location to spawn the unit at.
  */
 export const spawnAndKillUnit = (unitName: string, spawnLocation: Vector) => {
+    let unit: CDOTA_BaseNPC | undefined = undefined
+    let checkTimer: string | undefined = undefined
+
     return step((context, complete) => {
-        const unit = CreateUnitByName(unitName, spawnLocation, true, undefined, undefined, DOTATeam_t.DOTA_TEAM_NEUTRALS)
+        unit = CreateUnitByName(unitName, spawnLocation, true, undefined, undefined, DOTATeam_t.DOTA_TEAM_NEUTRALS)
 
         // Wait until the unit dies
         const checkIsDead = () => {
-            if (!unit.IsAlive()) {
+            if (unit && !unit.IsAlive()) {
                 complete()
             } else {
-                Timers.CreateTimer(1, () => checkIsDead())
+                checkTimer = Timers.CreateTimer(1, () => checkIsDead())
             }
         }
 
         checkIsDead()
+    }, context => {
+        if (checkTimer) {
+            Timers.RemoveTimer(checkTimer)
+            checkTimer = undefined
+        }
+
+        if (unit) {
+            unit.RemoveSelf()
+            unit = undefined
+        }
     })
 }
 
@@ -57,8 +77,15 @@ export const spawnAndKillUnit = (unitName: string, spawnLocation: Vector) => {
  * @param waitSeconds Time to wait before completion
  */
 export const wait = (waitSeconds: number) => {
+    let waitTimer: string | undefined = undefined
+
     return step((context, complete) => {
-        Timers.CreateTimer(waitSeconds, () => complete())
+        waitTimer = Timers.CreateTimer(waitSeconds, () => complete())
+    }, context => {
+        if (waitTimer) {
+            Timers.RemoveTimer(waitTimer)
+            waitTimer = undefined
+        }
     })
 }
 
@@ -67,12 +94,19 @@ export const wait = (waitSeconds: number) => {
  * @param target Target to focus the camera on. Can be undefined for freeing the camera.
  */
 export const setCameraTarget = (target: CBaseEntity | undefined) => {
+    let playerIds: PlayerID[] | undefined = undefined
+
     return step((context, complete) => {
-        const playerIds = findAllPlayers()
+        playerIds = findAllPlayers()
 
         // Focus all cameras on the target
         playerIds.forEach(playerId => PlayerResource.SetCameraTarget(playerId, target))
 
         complete()
+    }, context => {
+        if (playerIds) {
+            playerIds.forEach(playerId => PlayerResource.SetCameraTarget(playerId, undefined))
+            playerIds = undefined
+        }
     })
 }


### PR DESCRIPTION
`Tutorial` and `Section` were made into classes (previously just types and functions for them) as that seemed easier to handle many things such as keeping track of the current section in a tutorial. However `FunctionalSection` still exists which can be used to create a section from its functions.

Also added `stop` functions to `Tutorial`, `Section` and the tutorial graph system in order to allow skipping of sections (stopping the current section, setting up the state for new section, starting the new section). Implemented s top for the existing graph steps (eg. wait should clean up its timer).

`tutorial.start` can be called with a section index (might want to change that to name or something else?) to skip straight to a section. Can be called multiple times and should properly handle stopping of any sections that are in progress.

Finally also added a small readme to the sections folder which we might want to expand to allow more people to contribute sections.