### PR TITLE
Slight hero related improvements

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -2,7 +2,6 @@ import { reloadable } from "./lib/tstl-utils";
 import { section01, section02, section03, section_levelling } from "./Sections/index";
 import * as tut from "./Tutorial/Core";
 import { findAllPlayersID, getPlayerHero } from "./util";
-import "./modifiers/modifier_visible_through_fog" // temporary, I'm tired and want to sleep, we need to import modifiers somehow though
 
 declare global {
     interface CDOTAGamerules {

--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -199,8 +199,6 @@ export class GameMode {
 
             // Check if this is the real player's hero that just spawned, assign it to the gamemode entity if it is
             if (unit.IsRealHero()) {
-                unit.IsTempestDouble()
-
                 if (PlayerResource.IsValidPlayerID(unit.GetPlayerID()) && !PlayerResource.IsFakeClient(unit.GetPlayerID())) {
                     if (!this.playerHero || this.playerHero != unit) {
                         this.playerHero = unit;

--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -198,14 +198,11 @@ export class GameMode {
         if (unit.IsBaseNPC()) {
 
             // Check if this is the real player's hero that just spawned, assign it to the gamemode entity if it is
-            if (unit.IsRealHero())
-            {
+            if (unit.IsRealHero()) {
                 unit.IsTempestDouble()
 
-                if (PlayerResource.IsValidPlayerID(unit.GetPlayerID()) && !PlayerResource.IsFakeClient(unit.GetPlayerID()))
-                {
-                    if (!this.playerHero || this.playerHero != unit)
-                    {
+                if (PlayerResource.IsValidPlayerID(unit.GetPlayerID()) && !PlayerResource.IsFakeClient(unit.GetPlayerID())) {
+                    if (!this.playerHero || this.playerHero != unit) {
                         this.playerHero = unit;
                         this.OnPlayerHeroAssigned(unit);
                     }
@@ -221,8 +218,7 @@ export class GameMode {
                     }
 
                     const hero = getPlayerHero();
-                    if (hero)
-                    {
+                    if (hero) {
                         hero.SetGold(0, true);
                     }
                 });
@@ -230,8 +226,7 @@ export class GameMode {
         }
     }
 
-    OnPlayerHeroAssigned(hero: CDOTA_BaseNPC_Hero)
-    {
+    OnPlayerHeroAssigned(hero: CDOTA_BaseNPC_Hero) {
         hero.SetAbilityPoints(0);
     }
 }

--- a/game/scripts/vscripts/Sections/Section0.ts
+++ b/game/scripts/vscripts/Sections/Section0.ts
@@ -24,7 +24,7 @@ const start = (complete: () => void) => {
         tg.setCameraTarget(undefined),
         tg.wait(2),
         tg.goToLocation(Vector(0, 0, 0)),
-        tg.spawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0)),
+        tg.spawnAndKillUnit("npc_dota_hero_crystal_maiden", Vector(1000, 0, 0), true),
         tg.fork(
             tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0)),
             tg.spawnAndKillUnit("npc_dota_hero_luna", Vector(1500, 0, 0))

--- a/game/scripts/vscripts/Sections/Section_levelling.ts
+++ b/game/scripts/vscripts/Sections/Section_levelling.ts
@@ -19,7 +19,7 @@ const start = (complete: () => void) => {
     if (!hero) error("Could not find the player's hero.");
     const abilityName = "dragon_knight_breathe_fire";
 
-    for (let i = 0; i < DOTA_MAX_ABILITIES -1; i++) {
+    for (let i = 0; i < DOTA_MAX_ABILITIES - 1; i++) {
         const a = hero.GetAbilityByIndex(i);
         if (a) {
             hero.RemoveAbilityByHandle(a);

--- a/game/scripts/vscripts/Sections/Section_levelling.ts
+++ b/game/scripts/vscripts/Sections/Section_levelling.ts
@@ -16,22 +16,22 @@ const start = (complete: () => void) => {
     // 3. Highlight the skillbutton
 
     const hero = getPlayerHero();
+    if (!hero) error("Could not find the player's hero.");
     const abilityName = "dragon_knight_breathe_fire";
-    
 
     for (let i = 0; i < DOTA_MAX_ABILITIES -1; i++) {
         const a = hero.GetAbilityByIndex(i);
         if (a) {
-            hero.RemoveAbility(a.GetAbilityName());
+            hero.RemoveAbilityByHandle(a);
         }
-        
     }
 
     if (!hero.HasAbility(abilityName)) {
         hero.AddAbility(abilityName);
     }
-    const ability = hero.FindAbilityByName(abilityName)!;
-    
+    const ability = hero.FindAbilityByName(abilityName);
+    if (!ability) error("Dragon Knight's Breath Fire ability was not found.");
+
     hero.SetAbilityPoints(1);
     ability.SetUpgradeRecommended(true);
 

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -1,4 +1,4 @@
-import { findAllPlayersID } from "../util"
+import { findAllPlayersID, setUnitVisibilityThroughFogOfWar } from "../util"
 import { step } from "./Core"
 
 const isHeroNearby = (location: Vector, radius: number) => FindUnitsInRadius(
@@ -42,12 +42,17 @@ export const goToLocation = (location: Vector) => {
  * @param unitName Name of the unit to spawn.
  * @param spawnLocation Location to spawn the unit at.
  */
-export const spawnAndKillUnit = (unitName: string, spawnLocation: Vector) => {
+export const spawnAndKillUnit = (unitName: string, spawnLocation: Vector, visibleThroughFog?: boolean) => {
     let unit: CDOTA_BaseNPC | undefined = undefined
     let checkTimer: string | undefined = undefined
 
     return step((context, complete) => {
         unit = CreateUnitByName(unitName, spawnLocation, true, undefined, undefined, DotaTeam.NEUTRALS)
+
+        if (visibleThroughFog)
+        {
+            setUnitVisibilityThroughFogOfWar(unit, true);
+        }
 
         // Wait until the unit dies
         const checkIsDead = () => {

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -49,8 +49,7 @@ export const spawnAndKillUnit = (unitName: string, spawnLocation: Vector, visibl
     return step((context, complete) => {
         unit = CreateUnitByName(unitName, spawnLocation, true, undefined, undefined, DotaTeam.NEUTRALS)
 
-        if (visibleThroughFog)
-        {
+        if (visibleThroughFog) {
             setUnitVisibilityThroughFogOfWar(unit, true);
         }
 
@@ -120,7 +119,7 @@ export const setCameraTarget = (target: CBaseEntity | undefined) => {
  * Creates a tutorial step that waits for the hero to upgrade an ability
  * @param ability the ability that needs to be upgraded.
  */
-export const upgradeAbility = (ability:CDOTABaseAbility) => {
+export const upgradeAbility = (ability: CDOTABaseAbility) => {
     let checkTimer: string | undefined = undefined
     let abilityLevel = ability.GetLevel();
     let desiredLevel = ability.GetLevel() + 1;

--- a/game/scripts/vscripts/modifiers/modifier_visible_through_fog.ts
+++ b/game/scripts/vscripts/modifiers/modifier_visible_through_fog.ts
@@ -1,19 +1,16 @@
 import { BaseModifier, registerModifier } from "../lib/dota_ts_adapter";
 
 @registerModifier()
-export class modifier_visible_through_fog extends BaseModifier
-{
-    IsHidden() {return true}
-    IsDebuff() {return false}
-    IsPurgable() {return false}
+export class modifier_visible_through_fog extends BaseModifier {
+    IsHidden() { return true }
+    IsDebuff() { return false }
+    IsPurgable() { return false }
 
-    DeclareFunctions(): ModifierFunction[]
-    {
+    DeclareFunctions(): ModifierFunction[] {
         return [ModifierFunction.PROVIDES_FOW_POSITION]
     }
 
-    GetModifierProvidesFOWVision(): 0 | 1
-    {
+    GetModifierProvidesFOWVision(): 0 | 1 {
         return 1;
     }
 }

--- a/game/scripts/vscripts/modifiers/modifier_visible_through_fog.ts
+++ b/game/scripts/vscripts/modifiers/modifier_visible_through_fog.ts
@@ -1,0 +1,19 @@
+import { BaseModifier, registerModifier } from "../lib/dota_ts_adapter";
+
+@registerModifier()
+export class modifier_visible_through_fog extends BaseModifier
+{
+    IsHidden() {return true}
+    IsDebuff() {return false}
+    IsPurgable() {return false}
+
+    DeclareFunctions(): ModifierFunction[]
+    {
+        return [ModifierFunction.PROVIDES_FOW_POSITION]
+    }
+
+    GetModifierProvidesFOWVision(): 0 | 1
+    {
+        return 1;
+    }
+}

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -3,14 +3,11 @@ import "./modifiers/modifier_visible_through_fog"
 /**
  * Get a list of all valid players currently in the game.
  */
-export function findAllPlayersID(): PlayerID[]
-{
+export function findAllPlayersID(): PlayerID[] {
     const players: PlayerID[] = [];
 
-    for (let playerID = 0; playerID < DOTA_MAX_TEAM_PLAYERS; playerID++)
-    {
-        if (PlayerResource.IsValidPlayer(playerID))
-        {
+    for (let playerID = 0; playerID < DOTA_MAX_TEAM_PLAYERS; playerID++) {
+        if (PlayerResource.IsValidPlayer(playerID)) {
             players.push(playerID);
         }
     }
@@ -21,8 +18,7 @@ export function findAllPlayersID(): PlayerID[]
 /**
  * Get the player ID of the real player in the game.
  */
-export function findRealPlayerID(): PlayerID
-{
+export function findRealPlayerID(): PlayerID {
     let playerIDs = findAllPlayersID();
     const realPlayerID = playerIDs.filter(playerID => !PlayerResource.IsFakeClient(playerID))[0];
 
@@ -32,16 +28,14 @@ export function findRealPlayerID(): PlayerID
 /**
  * @returns The player's hero of the real player in the game.
  */
-export function getPlayerHero(): CDOTA_BaseNPC_Hero | undefined
-{
+export function getPlayerHero(): CDOTA_BaseNPC_Hero | undefined {
     return GameRules.Addon.playerHero;
 }
 
 /**
  * Set whether the player hero can earn XP from all sources. Defaults to false.
  */
-export function setCanPlayerHeroEarnXP(canEarnXP: boolean)
-{
+export function setCanPlayerHeroEarnXP(canEarnXP: boolean) {
     GameRules.Addon.canPlayerHeroEarnXP = canEarnXP;
 }
 
@@ -49,22 +43,18 @@ export function setCanPlayerHeroEarnXP(canEarnXP: boolean)
  * Check if the hero can currently earn XP from all sources.
  * @returns whether the hero can currently earn XP.
  */
-export function canPlayerHeroEarnXP(): boolean
-{
+export function canPlayerHeroEarnXP(): boolean {
     return GameRules.Addon.canPlayerHeroEarnXP;
 }
 
 /**
  * Sets whether a unit can be shown through the fog of war.
  */
-export function setUnitVisibilityThroughFogOfWar(unit: CDOTA_BaseNPC, visible: boolean)
-{
-    if (visible)
-    {
+export function setUnitVisibilityThroughFogOfWar(unit: CDOTA_BaseNPC, visible: boolean) {
+    if (visible) {
         unit.AddNewModifier(undefined, undefined, "modifier_visible_through_fog", {});
     }
-    else
-    {
+    else {
         unit.RemoveModifierByName("modifier_visible_through_fog");
     }
 }

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -1,3 +1,5 @@
+import "./modifiers/modifier_visible_through_fog"
+
 /**
  * Get a list of all valid players currently in the game.
  */

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -28,13 +28,11 @@ export function findRealPlayerID(): PlayerID
 }
 
 /**
- * Get the currently assigned hero of the real player in the game.
+ * @returns The player's hero of the real player in the game.
  */
-export function getPlayerHero(): CDOTA_BaseNPC_Hero
+export function getPlayerHero(): CDOTA_BaseNPC_Hero | undefined
 {
-    const playerID = findRealPlayerID();
-
-    return PlayerResource.GetPlayer(playerID)!.GetAssignedHero();
+    return GameRules.Addon.playerHero;
 }
 
 /**
@@ -52,4 +50,19 @@ export function setCanPlayerHeroEarnXP(canEarnXP: boolean)
 export function canPlayerHeroEarnXP(): boolean
 {
     return GameRules.Addon.canPlayerHeroEarnXP;
+}
+
+/**
+ * Sets whether a unit can be shown through the fog of war.
+ */
+export function setUnitVisibilityThroughFogOfWar(unit: CDOTA_BaseNPC, visible: boolean)
+{
+    if (visible)
+    {
+        unit.AddNewModifier(undefined, undefined, "modifier_visible_through_fog", {});
+    }
+    else
+    {
+        unit.RemoveModifierByName("modifier_visible_through_fog");
+    }
 }


### PR DESCRIPTION
This PR has a few improvements over the board:

* Player hero is now assigned when it is spawned. It is also reassigned properly when replacing the hero other heroes. This should no longer pose any issues with `getPlayerHero()` and should improve its process in general.
* When the player hero is assigned, `OnPlayerHeroAssigned()` is called for us to change things on the new hero. For starters, I've set the ability points of the player's hero to 0 (since he shouldn't be able to put any points when the game begins).
* `getPlayerHero()` can now return undefined, though it should almost never be the case. When getting the hero from `getPlayerHero()`, it should be validated that it is not undefined. (use if checks, not "!").
* Slightly revamped the Section Levelling tutorial portion to work with this requirement.
* Added a new modifier that shows a unit or a hero through the fog.
* Added a new function, `setUnitVisibilityThroughFogOfWar`, that adds or remove the above modifier from a unit.
* Added an optional boolean argument to `spawnAndKillUnit`. When returning true, the unit that was spawned will be visible from the fog using the above modifier.