### PR TITLE
Pacifism! Make love not war

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_tutorial_pacifist.ts
+++ b/game/scripts/vscripts/modifiers/modifier_tutorial_pacifist.ts
@@ -1,0 +1,14 @@
+import { BaseModifier, registerModifier } from "../lib/dota_ts_adapter";
+
+@registerModifier()
+export class modifier_tutorial_pacifist extends BaseModifier {
+    IsHidden() { return true }
+    IsDebuff() { return false }
+    IsPurgable() { return false }
+
+    CheckState(): Partial<Record<ModifierState, boolean>>
+    {
+        return {[ModifierState.DISARMED]: true,
+                [ModifierState.INVULNERABLE]: true}
+    }
+}

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -1,4 +1,5 @@
 import "./modifiers/modifier_visible_through_fog"
+import "./modifiers/modifier_tutorial_pacifist"
 
 /**
  * Get a list of all valid players currently in the game.
@@ -56,5 +57,15 @@ export function setUnitVisibilityThroughFogOfWar(unit: CDOTA_BaseNPC, visible: b
     }
     else {
         unit.RemoveModifierByName("modifier_visible_through_fog");
+    }
+}
+
+export function setUnitPacifist(unit: CDOTA_BaseNPC, isPacifist: boolean, duration?: number)
+{
+    if (isPacifist) {
+        unit.AddNewModifier(undefined, undefined, "modifier_tutorial_pacifist", {duration: duration});
+    }
+    else {
+        unit.RemoveModifierByName("modifier_tutorial_pacifist");
     }
 }


### PR DESCRIPTION
- Adds a new modifier: Pacifist.
- Units that have this modifier are disarmed and are invulnerable.
- They will not automatically acquire targets, will not try to fight, and cannot be attacked or have spells cast on in any way.  
- Technically, they can still cast items and use abilities to wage war, but without a proper AI that instructs them to do so, they wouldn't do that anyway.
- added new util function: `setUnitPacifist`, which applies or remove the pacifist modifier from a unit. In addition, a third optional argument can also apply the pacifist over a specified duration.