### PR TITLE
Added goal display logic

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -6,10 +6,15 @@ interface SectionStartedEvent {
     section: SectionName;
 }
 
+interface SetGoalsEvent {
+    goals: Goal[];
+}
+
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
     ui_loaded: {};
     detect_camera_movement: {};
     camera_movement_detected: {};
+    set_goals: SetGoalsEvent;
 }

--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -9,3 +9,8 @@ declare const enum CustomNpcKeys {
     SlacksMudGolem = "npc_mud_golem_slacks",
     SunsFanMudGolem = "npc_mud_golem_sunsfan",
 }
+
+type Goal = {
+    text: string
+    completed: boolean
+}

--- a/content/panorama/layout/custom_game/questspanel.xml
+++ b/content/panorama/layout/custom_game/questspanel.xml
@@ -1,5 +1,6 @@
 <root>
     <scripts>
+        <include src="file://{resources}/scripts/custom_game/questpanel.js" />
     </scripts>
     <styles>
         <include src="file://{resources}/styles/custom_game/questspanel.css" />
@@ -14,13 +15,13 @@
                 <Label class="QuestsTitle" text="#Quests" />
                 <Panel class="Divider" />
             </Panel>
-            <Panel hittest="false" class="QuestsPanelContainer">
+            <Panel hittest="false" id="QuestsPanelContainer">
                 <Panel class="Row" id="PlaceholderQuest1">
-                    <Panel id="QuestsUncompleted" />
+                    <Panel class="QuestsUncompleted" />
                     <Label class="QuestUncompletedText" text="Find USB Flash drive that contains Half-life 3." />
                 </Panel>
                 <Panel class="Row" id="PlaceholderQuest2">
-                    <Panel id="QuestsCompleted" />
+                    <Panel class="QuestsCompleted" />
                     <Label class="QuestCompletedText" text="Kill Omniknight with Techies three times. (3/3)" />
                 </Panel>
             </Panel>

--- a/content/panorama/scripts/custom_game/questpanel.ts
+++ b/content/panorama/scripts/custom_game/questpanel.ts
@@ -29,7 +29,5 @@ GameEvents.Subscribe("set_goals", event => {
         const label = $.CreatePanel("Label", rowPanel, "");
         label.AddClass(goal.completed ? "QuestCompletedText" : "QuestUncompletedText");
         label.text = goal.text;
-
-        $.Msg("Goal:", goal)
     }
 });

--- a/content/panorama/scripts/custom_game/questpanel.ts
+++ b/content/panorama/scripts/custom_game/questpanel.ts
@@ -1,0 +1,35 @@
+/**
+ * Converts an array that was passed from the server to a normal array.
+ * @param array Array passed from the server which got converted into an object.
+ */
+// TODO: Move this to a common place
+function parseServerArray<T>(array: { [key: string]: T }): T[] {
+    const result: T[] = [];
+
+    for (const index in array) {
+        result[parseInt(index) - 1] = array[index];
+    }
+
+    return result;
+}
+
+GameEvents.Subscribe("set_goals", event => {
+    // Clear the goals list and add each goal to the list.
+    const questPanel = $("#QuestsPanelContainer");
+    questPanel.RemoveAndDeleteChildren()
+
+    // TODO: Should we make sure that the goals are sorted by index?
+    for (const goal of parseServerArray(event.goals)) {
+        const rowPanel = $.CreatePanel("Panel", questPanel, "");
+        rowPanel.AddClass("Row");
+
+        const bulletPoint = $.CreatePanel("Panel", rowPanel, "");
+        bulletPoint.AddClass(goal.completed ? "QuestsCompleted" : "QuestsUncompleted");
+
+        const label = $.CreatePanel("Label", rowPanel, "");
+        label.AddClass(goal.completed ? "QuestCompletedText" : "QuestUncompletedText");
+        label.text = goal.text;
+
+        $.Msg("Goal:", goal)
+    }
+});

--- a/content/panorama/styles/custom_game/questspanel.css
+++ b/content/panorama/styles/custom_game/questspanel.css
@@ -10,7 +10,7 @@
 .QuestsPanelHeader {
     width: 100%;
     height: 6%;
-   
+
     vertical-align: top;
 }
 
@@ -46,7 +46,7 @@
     brightness: 0.6;
 }
 
-.QuestsPanelContainer {
+#QuestsPanelContainer {
     width: 100%;
     height: 94%;
     vertical-align: bottom;
@@ -59,7 +59,7 @@
     height: 5%;
 }
 
-#QuestsUncompleted {
+.QuestsUncompleted {
     width: 26px;
     height: 26px;
 
@@ -70,7 +70,7 @@
     brightness: 1.5;
 }
 
-#QuestsCompleted {
+.QuestsCompleted {
     width: 26px;
     height: 26px;
 

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -1,4 +1,4 @@
-import { findAllPlayersID, setUnitVisibilityThroughFogOfWar } from "../util"
+import { findAllPlayersID, setGoalsUI, setUnitVisibilityThroughFogOfWar } from "../util"
 import { step, TutorialContext } from "./Core"
 
 const isHeroNearby = (location: Vector, radius: number) => FindUnitsInRadius(
@@ -314,5 +314,30 @@ export const completeOnCheck = (checkFn: (context: TutorialContext) => boolean, 
             Timers.RemoveTimer(checkTimer)
             checkTimer = undefined
         }
+    })
+}
+
+/**
+ * Updates the goal UI periodically using the given function returning goals. Never completes and should be used together with forkAny().
+ * @param getGoals Function returning goals to display in the UI.
+ */
+export const trackGoals = (getGoals: (context: TutorialContext) => Goal[]) => {
+    let timer: string | undefined = undefined
+
+    return step((context, complete) => {
+        const track = () => {
+            setGoalsUI(getGoals(context))
+
+            timer = Timers.CreateTimer(0.5, () => track())
+        }
+
+        track()
+    }, context => {
+        if (timer) {
+            Timers.RemoveTimer(timer)
+            timer = undefined
+        }
+
+        setGoalsUI([])
     })
 }

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -81,3 +81,11 @@ export function getOrError<T>(obj: T | undefined, msg?: string): T {
 
     return obj
 }
+
+/**
+ * Updates the goal display.
+ * @param goals Goals to display in the UI.
+ */
+export function setGoalsUI(goals: Goal[]) {
+    CustomGameEventManager.Send_ServerToAllClients("set_goals", { goals });
+}


### PR DESCRIPTION
- Client-side logic for receiving goals and displaying them with the goals UI
- Utility function `setGoalsUI()` for sending goals from server to client (ie. set goals for UI)
- `trackGoals()` step which takes a function `context => Goal[]` that is periodically calling the util function mentioned above and never completes (except on stop). On stop clears the goal UI.
- Added `forkAny()` step which is like `fork()` but completes if *any* of its steps completed (the usual `fork()` only completes if all of them are completed) and then stops all the other steps
- Used goals in the camera unlock section using `forkAny()` with `trackGoals()` and the actual main step, so if the main step completes `trackGoals()` is stopped and the goal UI is cleared. If others find it more convenient, it's possible to use the `immediate()` to call the util function yourself instead of course.

Might want to move some of the goal logic out of the camera unlock section into a common file, if others like this approach of goals too (instead of immediate and util fn call yourself).

![image](https://user-images.githubusercontent.com/2614101/109372148-f75afa80-789f-11eb-998f-c548a63315c1.png)