### PR TITLE
New goal system

### DIFF
--- a/game/scripts/vscripts/Goals.ts
+++ b/game/scripts/vscripts/Goals.ts
@@ -1,0 +1,123 @@
+export abstract class TrackableGoal {
+    private _completed = false
+    private _started = false
+
+    /**
+     * Marks the goal as completed. Also marks it as started if it wasn't started already.
+     */
+    complete() {
+        this._started = true
+        this._completed = true
+    }
+
+    /**
+     * Marks the goal as started.
+     */
+    start() {
+        this._started = true
+    }
+
+    /**
+     * Whether the goal was completed.
+     */
+    get completed() { return this._completed }
+
+    /**
+     * Whether the goal was started.
+     */
+    get started() { return this._started }
+
+    abstract getGoal(): Goal
+}
+
+export class TrackableGoalBoolean extends TrackableGoal {
+    private _value: number = 0
+
+    constructor(readonly text: string) {
+        super()
+    }
+
+    getGoal(): Goal {
+        return {
+            completed: this.completed,
+            text: this.text
+        }
+    }
+}
+
+export class TrackableGoalNumeric extends TrackableGoal {
+    private _value: number = 0
+
+    constructor(readonly text: string, readonly maximum: number) {
+        super()
+    }
+
+    /**
+     * Sets the value of the numeric goal.
+     * @param value Value of the numeric goal.
+     */
+    setValue(value: number) {
+        if (value < 0 || value > this.maximum) {
+            Warning("Set numeric goal value outside of its range")
+        }
+
+        this._value = value
+    }
+
+    /**
+     * Gets the value of the numeric goal.
+     */
+    get value() {
+        return
+    }
+
+    getGoal(): Goal {
+        return {
+            completed: this.completed,
+            text: this.text + ": " + this._value + "/" + this.maximum
+        }
+    }
+}
+
+/**
+ * Creates trackable goals and provides a function for creating the UI goals from them.
+ */
+export class GoalTracker {
+    readonly states: TrackableGoal[] = []
+
+    /**
+     * Adds a boolean goal.
+     * @param text Text for the goal.
+     */
+    addBoolean(text: string): TrackableGoalBoolean {
+        const state = new TrackableGoalBoolean(text)
+        this.states.push(state)
+        return state
+    }
+
+    /**
+     * Adds a numeric goal that starts at 0 and goes up to maximum.
+     * @param text Text for the goal.
+     * @param maximum Maximum number for the goal.
+     */
+    addNumeric(text: string, maximum: number): TrackableGoalNumeric {
+        const state = new TrackableGoalNumeric(text, maximum)
+        this.states.push(state)
+        return state
+    }
+
+    /**
+     * Creates UI goals for the tracked goals.
+     */
+    getGoals(): Goal[] {
+        const goals: Goal[] = []
+
+        for (const state of this.states) {
+            if (state.started || state.completed) {
+                goals.push(state.getGoal())
+            }
+        }
+
+        return goals
+    }
+}

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -1,8 +1,8 @@
 import * as tg from "../../TutorialGraph/index"
 import * as tut from "../../Tutorial/Core"
 import { getOrError, getPlayerHero, setUnitPacifist } from "../../util"
-import { TutorialContext } from "../../TutorialGraph/index"
 import { RequiredState } from "../../Tutorial/RequiredState"
+import { GoalTracker } from "../../Goals"
 
 let graph: tg.TutorialStep | undefined = undefined
 
@@ -13,100 +13,71 @@ const requiredState: RequiredState = {
     slacksLocation: Vector(-6250, -6050, 256),
 }
 
-enum CameraUnlockContextKey {
-    CameraMove,
-    KillDummy,
-    KillSunsfan,
-}
-
-enum GoalState {
-    Started,
-    Completed
-}
-
 const targetDummySpawnOffset = Vector(500, 500, 0)
 
 const onStart = (complete: () => void) => {
     const radiantFountain = getOrError(Entities.FindByName(undefined, "ent_dota_fountain_good"))
 
-    // Return a list of goals to display depending on which parts we have started and completed.
-    const getGoals = (context: tg.TutorialContext) => {
-        const isGoalStarted = (key: CameraUnlockContextKey) => context[key] === GoalState.Started || context[key] === GoalState.Completed
-        const isGoalCompleted = (key: CameraUnlockContextKey) => context[key] === GoalState.Completed
+    const goalTracker = new GoalTracker()
+    const goalMoveCamera = goalTracker.addBoolean("Move your camera by dragging the cursor to the edge of your screen.")
+    const goalKillDummy = goalTracker.addBoolean("Attack and destroy the target dummy by right-clicking it.")
+    const goalKillSunsfan = goalTracker.addBoolean("Attack SUNSfan.")
 
-        const goals: Goal[] = []
-        const addGoal = (key: CameraUnlockContextKey, text: string) => {
-            if (isGoalStarted(key)) {
-                goals.push({ text: text, completed: isGoalCompleted(key) })
-            }
-        }
+    graph = tg.withGoals(ctx => goalTracker.getGoals(), tg.seq([
+        // Init
+        tg.wait(1),
+        tg.setCameraTarget(() => undefined),
+        tg.immediate(_ => getOrError(getPlayerHero()).SetMoveCapability(UnitMoveCapability.GROUND)), // This line can be removed once the movement section is there.
 
-        addGoal(CameraUnlockContextKey.CameraMove, "Move your camera by dragging the cursor to the edge of your screen.")
-        addGoal(CameraUnlockContextKey.KillDummy, "Attack and destroy the target dummy by right-clicking it.")
-        addGoal(CameraUnlockContextKey.KillSunsfan, "Attack SUNSfan.")
+        // Player should move his camera
+        tg.immediate(_ => print("Pre camera movement")),
+        tg.immediate(context => goalMoveCamera.start()),
+        tg.waitForCameraMovement(),
+        tg.immediate(_ => print("Post camera movement")),
+        tg.immediate(context => goalMoveCamera.complete()),
+        tg.textDialog(LocalizationKey.Script_1_Camera_1, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+        tg.setCameraTarget(_ => getOrError(getPlayerHero())),
+        tg.textDialog(LocalizationKey.Script_1_Camera_2, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
 
-        return goals
-    }
+        // Kill target dummy
+        tg.textDialog(LocalizationKey.Script_1_Camera_3, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
 
-    // Track the goals and do the main action in parallel. When the main action is done forkAny() will complete and clear the goals.
-    graph = tg.forkAny([
-        tg.trackGoals(getGoals),
-        tg.seq([
-            // Init
-            tg.wait(1),
-            tg.setCameraTarget(() => undefined),
-            tg.immediate(_ => getOrError(getPlayerHero()).SetMoveCapability(UnitMoveCapability.GROUND)), // This line can be removed once the movement section is there.
-
-            // Player should move his camera
-            tg.immediate(_ => print("Pre camera movement")),
-            tg.immediate(context => context[CameraUnlockContextKey.CameraMove] = GoalState.Started),
-            tg.waitForCameraMovement(),
-            tg.immediate(_ => print("Post camera movement")),
-            tg.immediate(context => context[CameraUnlockContextKey.CameraMove] = GoalState.Completed),
-            tg.textDialog(LocalizationKey.Script_1_Camera_1, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-            tg.setCameraTarget(_ => getOrError(getPlayerHero())),
-            tg.textDialog(LocalizationKey.Script_1_Camera_2, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
-
-            // Kill target dummy
-            tg.textDialog(LocalizationKey.Script_1_Camera_3, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-
-            tg.fork([
-                tg.seq([
-                    tg.textDialog(LocalizationKey.Script_1_Camera_4, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3), // TODO: Make the dummy say this line
-                    tg.textDialog(LocalizationKey.Script_1_Camera_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-                ]),
-                tg.seq([
-                    tg.immediate(context => context[CameraUnlockContextKey.KillDummy] = GoalState.Started),
-                    tg.spawnAndKillUnit(CustomNpcKeys.TargetDummy, radiantFountain.GetAbsOrigin().__add(targetDummySpawnOffset)),
-                    tg.immediate(context => context[CameraUnlockContextKey.KillDummy] = GoalState.Completed),
-                ])
+        tg.fork([
+            tg.seq([
+                tg.textDialog(LocalizationKey.Script_1_Camera_4, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3), // TODO: Make the dummy say this line
+                tg.textDialog(LocalizationKey.Script_1_Camera_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
             ]),
-            tg.textDialog(LocalizationKey.Script_1_Camera_6, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3), // TODO: Make the dummy say this line
-            tg.textDialog(LocalizationKey.Script_1_Camera_7, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
+            tg.seq([
+                tg.immediate(context => goalKillDummy.start()),
+                tg.spawnAndKillUnit(CustomNpcKeys.TargetDummy, radiantFountain.GetAbsOrigin().__add(targetDummySpawnOffset)),
+                tg.immediate(context => goalKillDummy.complete()),
+            ])
+        ]),
+        tg.textDialog(LocalizationKey.Script_1_Camera_6, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3), // TODO: Make the dummy say this line
+        tg.textDialog(LocalizationKey.Script_1_Camera_7, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
 
-            // Kill SUNSfan
-            tg.immediate(context => context[CameraUnlockContextKey.KillSunsfan] = GoalState.Started),
-            tg.immediate(context => setUnitPacifist(getOrError(context[CustomNpcKeys.SunsFanMudGolem]), false)),
-            tg.immediate(context => getOrError(context[CustomNpcKeys.SunsFanMudGolem] as CDOTA_BaseNPC).SetTeam(DotaTeam.NEUTRALS)),
-            tg.forkAny([
-                // Show a dialog after 10 seconds if the player didn't attack yet encouraging them.
-                tg.seq([
-                    tg.wait(10),
-                    tg.textDialog(LocalizationKey.Script_1_Camera_8, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-                    tg.neverComplete()
-                ]),
-                tg.completeOnCheck(context => {
-                    const golem = getOrError(context[CustomNpcKeys.SunsFanMudGolem] as CDOTA_BaseNPC | undefined)
-                    return !IsValidEntity(golem) || !golem.IsAlive() || golem.GetHealth() < golem.GetMaxHealth()
-                }, 0.2)
+        // Kill SUNSfan
+        tg.immediate(context => goalKillSunsfan.start()),
+        tg.immediate(context => setUnitPacifist(getOrError(context[CustomNpcKeys.SunsFanMudGolem]), false)),
+        tg.immediate(context => getOrError(context[CustomNpcKeys.SunsFanMudGolem] as CDOTA_BaseNPC).SetTeam(DotaTeam.NEUTRALS)),
+        tg.forkAny([
+            // Show a dialog after 10 seconds if the player didn't attack yet encouraging them.
+            tg.seq([
+                tg.wait(10),
+                tg.textDialog(LocalizationKey.Script_1_Camera_8, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+                tg.neverComplete()
             ]),
-            tg.immediate(context => context[CameraUnlockContextKey.KillSunsfan] = GoalState.Completed),
-            tg.textDialog(LocalizationKey.Script_1_Camera_9, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
-            tg.textDialog(LocalizationKey.Script_1_Camera_10, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-            tg.immediate(_ => getOrError(getPlayerHero()).HeroLevelUp(true)),
-            tg.wait(1),
-        ])
-    ])
+            tg.completeOnCheck(context => {
+                const golem = getOrError(context[CustomNpcKeys.SunsFanMudGolem] as CDOTA_BaseNPC | undefined)
+                return !IsValidEntity(golem) || !golem.IsAlive() || golem.GetHealth() < golem.GetMaxHealth()
+            }, 0.2)
+        ]),
+        tg.immediate(context => goalKillSunsfan.complete()),
+        tg.textDialog(LocalizationKey.Script_1_Camera_9, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
+        tg.textDialog(LocalizationKey.Script_1_Camera_10, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+        tg.immediate(_ => getOrError(getPlayerHero()).HeroLevelUp(true)),
+        tg.wait(1),
+    ]))
 
     graph.start(GameRules.Addon.context, () => {
         complete()

--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -3,21 +3,12 @@ import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { displayDotaErrorMessage, findRealPlayerID, getPlayerHero } from "../../util";
 import { TutorialContext } from "../../TutorialGraph/index";
+import { GoalTracker } from "../../Goals";
 
 const sectionName: SectionName = SectionName.Chapter1_ShopUI;
 let graph: tg.TutorialStep | undefined = undefined
 let waitingForPlayerToPurchaseTango = false;
 let playerBoughtTango = false;
-
-enum ShopUIGoalKeys {
-    OpenShop,
-    BuyTango
-}
-
-enum GoalState {
-    Started,
-    Completed,
-}
 
 const requiredState: RequiredState = {
     requireSlacksGolem: true,
@@ -32,47 +23,28 @@ const onStart = (complete: () => void) => {
     const playerHero = getPlayerHero();
     if (!playerHero) error("Could not find the player's hero.");
 
-    // Return a list of goals to display depending on which parts we have started and completed.
-    const getGoals = (context: TutorialContext) => {
+    const goalTracker = new GoalTracker();
+    const goalOpenShop = goalTracker.addBoolean("Open the shop.");
+    const goalBuyTango = goalTracker.addBoolean("Use the gold provided to purchase a Tango.");
 
-        const isGoalStarted = (key: ShopUIGoalKeys) =>
-            context[key] === GoalState.Started ||
-            context[key] === GoalState.Completed;
-        const isGoalCompleted = (key: ShopUIGoalKeys) =>
-            context[key] === GoalState.Completed;
-
-        const goals: Goal[] = [];
-        const addGoal = (key: ShopUIGoalKeys, text: string) => {
-            if (isGoalStarted(key)) {
-                goals.push({ text: text, completed: isGoalCompleted(key) });
-            }
-        };
-
-        addGoal(ShopUIGoalKeys.OpenShop, "Open the shop.");
-        addGoal(ShopUIGoalKeys.BuyTango, "Use the gold provided to purchase a Tango.");
-
-        return goals;
-    };
-
-    graph = tg.forkAny([
-        tg.trackGoals(getGoals),
+    graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
             tg.immediate((context) => {
-                context[ShopUIGoalKeys.OpenShop] = GoalState.Started;
+                goalOpenShop.start();
                 playerHero.SetGold(90, true);
                 waitingForPlayerToPurchaseTango = true;
             }),
             tg.wait(10),
             tg.completeOnCheck(context => {
-                context[ShopUIGoalKeys.OpenShop] = GoalState.Completed;
-                context[ShopUIGoalKeys.BuyTango] = GoalState.Started;
+                goalOpenShop.complete();
+                goalBuyTango.start();
                 return playerBoughtTango;
             }, 0.2),
             tg.immediate((context) => {
-                context[ShopUIGoalKeys.BuyTango] = GoalState.Completed;
+                goalBuyTango.complete()
             })
         ])
-    ])
+    )
 
     graph.start(GameRules.Addon.context, () => {
         print("Completed", sectionName)

--- a/game/scripts/vscripts/Sections/Chapter1/SectionTemplate.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionTemplate.ts
@@ -1,6 +1,7 @@
 import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
+import { GoalTracker } from "../../Goals";
 
 const sectionName: SectionName = SectionName.Chapter1_Opening;
 
@@ -13,55 +14,25 @@ const requiredState: RequiredState = {
 };
 
 /**
- * Keys used for the tutorial graph context in this section.
- */
-enum ContextKey {
-    Dummy
-}
-
-enum GoalState {
-    Started,
-    Completed
-}
-
-/**
- * Return a list of goals to display depending on which parts we have started and completed.
- * @param context Context of the tutorial graph which can store the goals' states.
- */
-const getGoals = (context: tg.TutorialContext) => {
-    const isGoalStarted = (key: ContextKey) => context[key] === GoalState.Started || context[key] === GoalState.Completed
-    const isGoalCompleted = (key: ContextKey) => context[key] === GoalState.Completed
-
-    const goals: Goal[] = []
-    const addGoal = (key: ContextKey, text: string) => {
-        if (isGoalStarted(key)) {
-            goals.push({ text: text, completed: isGoalCompleted(key) })
-        }
-    }
-
-    addGoal(ContextKey.Dummy, "Do something.")
-
-    return goals
-}
-
-/**
  * Called when the section is started and should contain the main logic.
  * @param complete Call this function to complete the section.
  */
 function onStart(complete: () => void) {
     print("Starting", sectionName);
 
-    graph = tg.forkAny([
-        tg.trackGoals(getGoals),
+    const goalTracker = new GoalTracker();
+    const goalDummy = goalTracker.addBoolean("Do something.");
+
+    graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
             tg.wait(1),
-            tg.immediate(context => context[ContextKey.Dummy] = GoalState.Started),
+            tg.immediate(context => goalDummy.start()),
             tg.immediate(context => print("Hello world")),
             tg.wait(5),
-            tg.immediate(context => context[ContextKey.Dummy] = GoalState.Completed),
+            tg.immediate(context => goalDummy.complete()),
             tg.wait(5),
         ])
-    ])
+    )
 
     graph.start(GameRules.Addon.context, () => {
         print("Completed", sectionName);

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -410,6 +410,37 @@ export const trackGoals = (goals: tg.StepArgument<Goal[]>) => {
 }
 
 /**
+ * Creates a step that tracks goals at the same time as executing a given step. Completes when the given step was completed.
+ * @param goals Goals to track.
+ * @param step Step to execute.
+ */
+export const withGoals = (goals: tg.StepArgument<Goal[]>, step: tg.TutorialStep) => {
+    let timer: string | undefined = undefined
+
+    return tg.step((context, complete) => {
+        const track = () => {
+            const actualGoals = tg.getArg(goals, context)
+            setGoalsUI(actualGoals)
+
+            timer = Timers.CreateTimer(0.5, () => track())
+        }
+
+        track()
+
+        step.start(context, () => complete())
+    }, context => {
+        if (timer) {
+            Timers.RemoveTimer(timer)
+            timer = undefined
+        }
+
+        setGoalsUI([])
+
+        step.stop(context)
+    })
+}
+
+/**
  * Plays a dialog with sound and text and waits for the sound to finish before completing.
  * @param soundName Name of the sound
  * @param text Text to display during the dialog


### PR DESCRIPTION
- Added `GoalTracker` to which goals can be added, the fns return a goal object which has `start()`, `complete()` methods etc.
- Different kinds of goals can be created easily (boolean and numeric exist so far)
- Added `withGoals()` as a simpler alternative to using `forkAny()` and `trackGoals()` that just takes the goal fn and the step to execute

So far I only made Chapter 1 use new system as I didn't want to mess with anyone elses code yet (conflicts). `trackGoals()` should probably be removed once every chapter moves over to the new system.

Simple example below
![image](https://user-images.githubusercontent.com/2614101/109574960-bf92c380-7ae8-11eb-82ae-d64040f34d26.png)