### PR TITLE
Add command / hotkey and modifier-key detection

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -54,11 +54,11 @@ interface DialogConfirmExpireEvent {
     DialogLine: number;
 }
 
-interface DetectCommand {
+interface DetectCommandEvent {
     command: number //DOTAKeybindCommand_t
 }
 
-interface CommandDetected {
+interface CommandDetectedEvent {
     command: number //DOTAKeybindCommand_t
 }
 
@@ -75,6 +75,6 @@ interface CustomGameEventDeclarations {
     detect_camera_movement: {};
     camera_movement_detected: {};
     set_goals: SetGoalsEvent;
-    detect_command: DetectCommand;
-    command_detected: CommandDetected;
+    detect_command: DetectCommandEvent;
+    command_detected: CommandDetectedEvent;
 }

--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -62,6 +62,14 @@ interface CommandDetectedEvent {
     command: number //DOTAKeybindCommand_t
 }
 
+interface DetectModifierKeyEventEvent {
+    key: ModifierKey
+}
+
+interface ModifierKeyDetectedEvent {
+    key: ModifierKey
+}
+
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
@@ -77,4 +85,6 @@ interface CustomGameEventDeclarations {
     set_goals: SetGoalsEvent;
     detect_command: DetectCommandEvent;
     command_detected: CommandDetectedEvent;
+    detect_modifier_key: DetectModifierKeyEventEvent;
+    modifier_key_detected: ModifierKeyDetectedEvent;
 }

--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -54,6 +54,14 @@ interface DialogConfirmExpireEvent {
     DialogLine: number;
 }
 
+interface DetectCommand {
+    command: number //DOTAKeybindCommand_t
+}
+
+interface CommandDetected {
+    command: number //DOTAKeybindCommand_t
+}
+
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
@@ -67,4 +75,6 @@ interface CustomGameEventDeclarations {
     detect_camera_movement: {};
     camera_movement_detected: {};
     set_goals: SetGoalsEvent;
+    detect_command: DetectCommand;
+    command_detected: CommandDetected;
 }

--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -62,7 +62,7 @@ interface CommandDetectedEvent {
     command: number //DOTAKeybindCommand_t
 }
 
-interface DetectModifierKeyEventEvent {
+interface DetectModifierKeyEvent {
     key: ModifierKey
 }
 
@@ -85,6 +85,6 @@ interface CustomGameEventDeclarations {
     set_goals: SetGoalsEvent;
     detect_command: DetectCommandEvent;
     command_detected: CommandDetectedEvent;
-    detect_modifier_key: DetectModifierKeyEventEvent;
+    detect_modifier_key: DetectModifierKeyEvent;
     modifier_key_detected: ModifierKeyDetectedEvent;
 }

--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -44,4 +44,5 @@ interface UnitDialog {
 declare const enum ModifierKey {
     Alt,
     Shift,
+    Control,
 }

--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -40,3 +40,8 @@ interface UnitDialog {
     currentLine: number;
     lines: DialogData[];
 }
+
+declare const enum ModifierKey {
+    Alt,
+    Shift,
+}

--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -3,6 +3,7 @@
         <include src="file://{resources}/scripts/custom_game/section-selector.js" />
         <include src="file://{resources}/scripts/custom_game/move-camera.js" />
         <include src="file://{resources}/scripts/custom_game/command-detection.js" />
+        <include src="file://{resources}/scripts/custom_game/modifier-key-detection.js" />
         <!-- <include src="file://{resources}/scripts/custom_game/manifest.js" /> -->
     </scripts>
     <Panel>

--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -2,6 +2,7 @@
     <scripts>
         <include src="file://{resources}/scripts/custom_game/section-selector.js" />
         <include src="file://{resources}/scripts/custom_game/move-camera.js" />
+        <include src="file://{resources}/scripts/custom_game/command-detection.js" />
         <!-- <include src="file://{resources}/scripts/custom_game/manifest.js" /> -->
     </scripts>
     <Panel>

--- a/content/panorama/scripts/custom_game/command-detection.ts
+++ b/content/panorama/scripts/custom_game/command-detection.ts
@@ -1,0 +1,28 @@
+/**
+ * Dictionary object for commands to detect.
+ */
+const shouldDetectCommand: { [key: number]: boolean } = {};
+const addedKeybind: { [key: string]: boolean } = {};
+
+function onCommand(command: DOTAKeybindCommand_t) {
+    if (shouldDetectCommand[command]) {
+        GameEvents.SendCustomGameEventToServer("command_detected", { command: command });
+        shouldDetectCommand[command] = false;
+    }
+}
+
+GameEvents.Subscribe("detect_command", event => {
+    const { command } = event;
+
+    shouldDetectCommand[command] = true;
+
+    const keybind = Game.GetKeybindForCommand(command);
+
+    if (!addedKeybind[keybind]) {
+        const commandName = `Command_${event.command}`
+
+        Game.CreateCustomKeyBind(keybind, commandName)
+        Game.AddCommand(commandName, () => onCommand(command), "", 0);
+        addedKeybind[keybind] = true
+    }
+});

--- a/content/panorama/scripts/custom_game/command-detection.ts
+++ b/content/panorama/scripts/custom_game/command-detection.ts
@@ -19,10 +19,10 @@ GameEvents.Subscribe("detect_command", event => {
     const keybind = Game.GetKeybindForCommand(command);
 
     if (!addedKeybind[keybind]) {
-        const commandName = `Command_${event.command}`
+        const commandName = `Command_${event.command}`;
 
-        Game.CreateCustomKeyBind(keybind, commandName)
+        Game.CreateCustomKeyBind(keybind, commandName);
         Game.AddCommand(commandName, () => onCommand(command), "", 0);
-        addedKeybind[keybind] = true
+        addedKeybind[keybind] = true;
     }
 });

--- a/content/panorama/scripts/custom_game/command-detection.ts
+++ b/content/panorama/scripts/custom_game/command-detection.ts
@@ -1,28 +1,28 @@
 /**
  * Dictionary object for commands to detect.
  */
-const shouldDetectCommand: { [key: number]: boolean } = {};
-const addedKeybind: { [key: string]: boolean } = {};
+const shouldDetectCommand = new Set<number>();
+const addedKeybind = new Set<string>();
 
 function onCommand(command: DOTAKeybindCommand_t) {
-    if (shouldDetectCommand[command]) {
+    if (shouldDetectCommand.has(command)) {
         GameEvents.SendCustomGameEventToServer("command_detected", { command: command });
-        shouldDetectCommand[command] = false;
+        shouldDetectCommand.delete(command);
     }
 }
 
 GameEvents.Subscribe("detect_command", event => {
     const { command } = event;
 
-    shouldDetectCommand[command] = true;
+    shouldDetectCommand.add(command);
 
     const keybind = Game.GetKeybindForCommand(command);
 
-    if (!addedKeybind[keybind]) {
+    if (!addedKeybind.has(keybind)) {
         const commandName = `Command_${event.command}`;
 
         Game.CreateCustomKeyBind(keybind, commandName);
         Game.AddCommand(commandName, () => onCommand(command), "", 0);
-        addedKeybind[keybind] = true;
+        addedKeybind.add(keybind);
     }
 });

--- a/content/panorama/scripts/custom_game/modifier-key-detection.ts
+++ b/content/panorama/scripts/custom_game/modifier-key-detection.ts
@@ -2,20 +2,19 @@ const shouldDetectModifierKeys: { [key: string]: boolean } = {};
 
 function detectModifierKeys() {
     for (const key of Object.keys(shouldDetectModifierKeys).map(k => parseInt(k) as ModifierKey)) {
-
         if (shouldDetectModifierKeys[key]) {
-            let isDown = false
+            let isDown = false;
 
             switch (key) {
                 case ModifierKey.Alt:
-                    isDown = GameUI.IsAltDown()
-                    break
+                    isDown = GameUI.IsAltDown();
+                    break;
                 case ModifierKey.Shift:
-                    isDown = GameUI.IsShiftDown()
-                    break
+                    isDown = GameUI.IsShiftDown();
+                    break;
                 case ModifierKey.Control:
-                    isDown = GameUI.IsControlDown()
-                    break
+                    isDown = GameUI.IsControlDown();
+                    break;
             }
 
             if (isDown) {
@@ -25,10 +24,10 @@ function detectModifierKeys() {
         }
     }
 
-    $.Schedule(0.2, detectModifierKeys)
+    $.Schedule(0.2, detectModifierKeys);
 }
 
-detectModifierKeys()
+detectModifierKeys();
 
 GameEvents.Subscribe("detect_modifier_key", event => {
     shouldDetectModifierKeys[event.key] = true;

--- a/content/panorama/scripts/custom_game/modifier-key-detection.ts
+++ b/content/panorama/scripts/custom_game/modifier-key-detection.ts
@@ -1,26 +1,24 @@
-const shouldDetectModifierKeys: { [key: string]: boolean } = {};
+const shouldDetectModifierKeys = new Set<ModifierKey>();
 
 function detectModifierKeys() {
-    for (const key of Object.keys(shouldDetectModifierKeys).map(k => parseInt(k) as ModifierKey)) {
-        if (shouldDetectModifierKeys[key]) {
-            let isDown = false;
+    for (const key of shouldDetectModifierKeys.values()) {
+        let isDown = false;
 
-            switch (key) {
-                case ModifierKey.Alt:
-                    isDown = GameUI.IsAltDown();
-                    break;
-                case ModifierKey.Shift:
-                    isDown = GameUI.IsShiftDown();
-                    break;
-                case ModifierKey.Control:
-                    isDown = GameUI.IsControlDown();
-                    break;
-            }
+        switch (key) {
+            case ModifierKey.Alt:
+                isDown = GameUI.IsAltDown();
+                break;
+            case ModifierKey.Shift:
+                isDown = GameUI.IsShiftDown();
+                break;
+            case ModifierKey.Control:
+                isDown = GameUI.IsControlDown();
+                break;
+        }
 
-            if (isDown) {
-                GameEvents.SendCustomGameEventToServer("modifier_key_detected", { key });
-                shouldDetectModifierKeys[key] = false;
-            }
+        if (isDown) {
+            GameEvents.SendCustomGameEventToServer("modifier_key_detected", { key });
+            shouldDetectModifierKeys.delete(key);
         }
     }
 
@@ -30,5 +28,5 @@ function detectModifierKeys() {
 detectModifierKeys();
 
 GameEvents.Subscribe("detect_modifier_key", event => {
-    shouldDetectModifierKeys[event.key] = true;
+    shouldDetectModifierKeys.add(event.key);
 });

--- a/content/panorama/scripts/custom_game/modifier-key-detection.ts
+++ b/content/panorama/scripts/custom_game/modifier-key-detection.ts
@@ -13,6 +13,9 @@ function detectModifierKeys() {
                 case ModifierKey.Shift:
                     isDown = GameUI.IsShiftDown()
                     break
+                case ModifierKey.Control:
+                    isDown = GameUI.IsControlDown()
+                    break
             }
 
             if (isDown) {

--- a/content/panorama/scripts/custom_game/modifier-key-detection.ts
+++ b/content/panorama/scripts/custom_game/modifier-key-detection.ts
@@ -1,0 +1,32 @@
+const shouldDetectModifierKeys: { [key: string]: boolean } = {};
+
+function detectModifierKeys() {
+    for (const key of Object.keys(shouldDetectModifierKeys).map(k => parseInt(k) as ModifierKey)) {
+
+        if (shouldDetectModifierKeys[key]) {
+            let isDown = false
+
+            switch (key) {
+                case ModifierKey.Alt:
+                    isDown = GameUI.IsAltDown()
+                    break
+                case ModifierKey.Shift:
+                    isDown = GameUI.IsShiftDown()
+                    break
+            }
+
+            if (isDown) {
+                GameEvents.SendCustomGameEventToServer("modifier_key_detected", { key });
+                shouldDetectModifierKeys[key] = false;
+            }
+        }
+    }
+
+    $.Schedule(0.2, detectModifierKeys)
+}
+
+detectModifierKeys()
+
+GameEvents.Subscribe("detect_modifier_key", event => {
+    shouldDetectModifierKeys[event.key] = true;
+});

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -57,8 +57,6 @@ const onStart = (complete: () => void) => {
             tg.setCameraTarget(() => undefined),
             tg.immediate(_ => getOrError(getPlayerHero()).SetMoveCapability(UnitMoveCapability.GROUND)), // This line can be removed once the movement section is there.
 
-            tg.waitForModifierKey(ModifierKey.Alt),
-
             // Player should move his camera
             tg.immediate(_ => print("Pre camera movement")),
             tg.immediate(context => context[CameraUnlockContextKey.CameraMove] = GoalState.Started),

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -57,6 +57,8 @@ const onStart = (complete: () => void) => {
             tg.setCameraTarget(() => undefined),
             tg.immediate(_ => getOrError(getPlayerHero()).SetMoveCapability(UnitMoveCapability.GROUND)), // This line can be removed once the movement section is there.
 
+            tg.waitForModifierKey(ModifierKey.Alt),
+
             // Player should move his camera
             tg.immediate(_ => print("Pre camera movement")),
             tg.immediate(context => context[CameraUnlockContextKey.CameraMove] = GoalState.Started),

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -340,6 +340,34 @@ export const waitForCommand = (command: number) => {
 }
 
 /**
+ * Waits until a modifier key was held down.
+ * @param key Modifier key to wait for.
+ */
+export const waitForModifierKey = (key: ModifierKey) => {
+    let listenerId: CustomGameEventListenerID | undefined = undefined
+
+    return tg.step((context, complete) => {
+        listenerId = CustomGameEventManager.RegisterListener("modifier_key_detected", (source, event) => {
+            if (event.key === key) {
+                if (listenerId) {
+                    CustomGameEventManager.UnregisterListener(listenerId)
+                    listenerId = undefined
+                }
+
+                complete()
+            }
+        })
+
+        CustomGameEventManager.Send_ServerToAllClients("detect_modifier_key", { key });
+    }, context => {
+        if (listenerId) {
+            CustomGameEventManager.UnregisterListener(listenerId)
+            listenerId = undefined
+        }
+    })
+}
+
+/**
  * Calls a function and completes immediately.
  * @param fn Function to call. Gets passed the context.
  * @param stopFn Optional function to call on stop. Gets passed the context.

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -312,6 +312,34 @@ export const waitForCameraMovement = () => {
 }
 
 /**
+ * Waits for a command to be executed. See panorama's DOTAKeybindCommand_t for the commands. Overrides the default behavior for the command so this can only be used if we merely want to detect the hotkey.
+ * @param command Command to wait for. See DOTAKeybindCommand_t.
+ */
+export const waitForCommand = (command: number) => {
+    let listenerId: CustomGameEventListenerID | undefined = undefined
+
+    return tg.step((context, complete) => {
+        listenerId = CustomGameEventManager.RegisterListener("command_detected", (source, event) => {
+            if (event.command === command) {
+                if (listenerId) {
+                    CustomGameEventManager.UnregisterListener(listenerId)
+                    listenerId = undefined
+                }
+
+                complete()
+            }
+        })
+
+        CustomGameEventManager.Send_ServerToAllClients("detect_command", { command });
+    }, context => {
+        if (listenerId) {
+            CustomGameEventManager.UnregisterListener(listenerId)
+            listenerId = undefined
+        }
+    })
+}
+
+/**
  * Calls a function and completes immediately.
  * @param fn Function to call. Gets passed the context.
  * @param stopFn Optional function to call on stop. Gets passed the context.


### PR DESCRIPTION
Two things in this

### Detect command
- Waits for a hotkey for a command (start voice chat, open chat wheel, ...) to be pressed
- Disables the original functionality of the command (makes using it for chat wheel rather useless, but still useful for the voice key detection I guess)

Would be nice if we could make this not disable the old functionality so we can use it for detecting chatwheel too.

### Detect modifier key
- Uses `IsAltDown()` etc. to detect whether a modifier key was down
- Can be used for the section where holding ALT is required for highlighting ward and camp range

