### PR TITLE
Fixed goal bug in Shop UI section

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -35,9 +35,11 @@ const onStart = (complete: () => void) => {
                 waitingForPlayerToPurchaseTango = true;
             }),
             tg.wait(10),
-            tg.completeOnCheck(context => {
+            tg.immediate(_ => {
                 goalOpenShop.complete();
                 goalBuyTango.start();
+            }),
+            tg.completeOnCheck(context => {
                 return playerBoughtTango;
             }, 0.2),
             tg.immediate((context) => {


### PR DESCRIPTION
Accidentally had the goal start and complete in the `completeOnCheck` loop which worked fine before since we were just setting the context but messes up with the new goal system.