### PR TITLE
Add inline localization to panorama

### DIFF
--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -1,5 +1,6 @@
 <root>
     <scripts>
+        <include src="file://{resources}/scripts/custom_game/localization.js" />
         <include src="file://{resources}/scripts/custom_game/section-selector.js" />
         <include src="file://{resources}/scripts/custom_game/move-camera.js" />
         <include src="file://{resources}/scripts/custom_game/command-detection.js" />

--- a/content/panorama/scripts/custom_game/localization.ts
+++ b/content/panorama/scripts/custom_game/localization.ts
@@ -1,4 +1,4 @@
-const localizationRegex = /#\S+/g; // '#' followed by one or more non-whitespaces
+const localizationRegex = /#[a-zA-Z0-9_-]+/g; // '#' followed by one or more non-whitespaces
 
 const localizeInline = (text: string): string => text.includes("#") ? text.replace(localizationRegex, match => $.Localize(match)) : $.Localize(text)
 

--- a/content/panorama/scripts/custom_game/localization.ts
+++ b/content/panorama/scripts/custom_game/localization.ts
@@ -1,0 +1,15 @@
+const localizationRegex = /#\S+/g; // '#' followed by one or more non-whitespaces
+
+const localizeInline = (text: string): string => text.includes("#") ? text.replace(localizationRegex, match => $.Localize(match)) : $.Localize(text)
+
+interface CustomUIConfig {
+    /**
+     * Replaces occurences of localizable keys starting with '#' within the string and returns the result.
+     * If the string does not contain '#' uses the normal localization function.
+     * Example: "Text Text #Token1 Text #Token2" => "Text Text Token one Text Token two"
+     * @param text String within which we want to replace localization keys.
+     */
+    localizeInline: typeof localizeInline;
+}
+
+GameUI.CustomUIConfig().localizeInline = localizeInline;

--- a/content/panorama/scripts/custom_game/localization.ts
+++ b/content/panorama/scripts/custom_game/localization.ts
@@ -1,4 +1,4 @@
-const localizationRegex = /#[a-zA-Z0-9_-]+/g; // '#' followed by one or more non-whitespaces
+const localizationRegex = /#[a-zA-Z0-9_-]+/g; // '#' followed by one or more letters/digits/underscores/hyphens
 
 const localizeInline = (text: string): string => text.includes("#") ? text.replace(localizationRegex, match => $.Localize(match)) : $.Localize(text)
 
@@ -6,6 +6,7 @@ interface CustomUIConfig {
     /**
      * Replaces occurences of localizable keys starting with '#' within the string and returns the result.
      * If the string does not contain '#' uses the normal localization function.
+     * The localization tokens can be composed of letters, digits, underscores and hyphens.
      * Example: "Text Text #Token1 Text #Token2" => "Text Text Token one Text Token two"
      * @param text String within which we want to replace localization keys.
      */

--- a/content/panorama/scripts/custom_game/questpanel.ts
+++ b/content/panorama/scripts/custom_game/questpanel.ts
@@ -14,9 +14,11 @@ function parseServerArray<T>(array: { [key: string]: T }): T[] {
 }
 
 GameEvents.Subscribe("set_goals", event => {
+    const localizeInline = GameUI.CustomUIConfig().localizeInline;
+
     // Clear the goals list and add each goal to the list.
     const questPanel = $("#QuestsPanelContainer");
-    questPanel.RemoveAndDeleteChildren()
+    questPanel.RemoveAndDeleteChildren();
 
     // TODO: Should we make sure that the goals are sorted by index?
     for (const goal of parseServerArray(event.goals)) {
@@ -28,6 +30,6 @@ GameEvents.Subscribe("set_goals", event => {
 
         const label = $.CreatePanel("Label", rowPanel, "");
         label.AddClass(goal.completed ? "QuestCompletedText" : "QuestUncompletedText");
-        label.text = goal.text;
+        label.text = localizeInline(goal.text);
     }
 });


### PR DESCRIPTION
Will replace occurences of localization keys prefixed with `#` in the given string. Useful for goals where the server can give us a string that is the key concatenated with a number (`#LocKey: 5/7`) so we dont need to do any special handling on the panorama side.

Note: the localization token can contain only letters, digits, underscores and hyphens so in the numeric example above the colon without a whitespace before it is fine.

Another Example: `"Text Text #Token1 Text #Token2"` becomes `"Text Text Token one Text Token two"`

https://github.com/ModDota/dota-tutorial/issues/106