### PR TITLE
Polished camera unlock section

### DIFF
--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -20,7 +20,7 @@ declare const enum CustomNpcKeys {
     RadiantRangedCreep = "npc_dota_tutorial_radiant_ranged_creep",
     RadiantMeleeCreep = "npc_dota_tutorial_radiant_melee_creep",
     GodzMudGolem = "npc_mud_golem_godz",
-    TargetDummy = "npc_target_dummy",
+    TargetDummy = "npc_dota_tutorial_target_dummy",
 }
 
 declare const enum CustomAbilityKeys {

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -29,6 +29,7 @@
         "npc_dota_tutorial_radiant_ranged_creep" "Ranged Creep"
         "npc_dota_tutorial_dire_melee_creep" "Melee Creep"
         "npc_dota_tutorial_dire_ranged_creep" "Ranged Creep"
+        "npc_dota_tutorial_target_dummy" "Target Dummy"
         "dota_item_build_title_default" "Items for future victim"
 
         "Script_1_Opening_1" "Oh look at this! New blood! The dragon knight himself!"

--- a/game/scripts/npc/npc_units_custom.txt
+++ b/game/scripts/npc/npc_units_custom.txt
@@ -494,7 +494,7 @@
 		//Inventory
 	}
 
-    "npc_target_dummy"
+    "npc_dota_tutorial_target_dummy"
     {
         // General
         //----------------------------------------------------------------

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -38,7 +38,7 @@ const onStart = (complete: () => void) => {
         // Spawn dummy and play some dialog about it. Freeze the hero during this and focus camera on the dummy.
         tg.immediate(_ => freezePlayerHero(true)),
         tg.textDialog(LocalizationKey.Script_1_Camera_3, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-        tg.spawnUnit(CustomNpcKeys.TargetDummy, radiantFountain.GetAbsOrigin().__add(targetDummySpawnOffset), DotaTeam.NEUTRALS, CustomNpcKeys.TargetDummy),
+        tg.spawnUnit(CustomNpcKeys.TargetDummy, radiantFountain.GetAbsOrigin().__add(targetDummySpawnOffset), DotaTeam.NEUTRALS, CustomNpcKeys.TargetDummy, true),
         tg.setCameraTarget(ctx => ctx[CustomNpcKeys.TargetDummy]),
         tg.textDialog(LocalizationKey.Script_1_Camera_4, ctx => ctx[CustomNpcKeys.TargetDummy], 3),
         tg.textDialog(LocalizationKey.Script_1_Camera_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -1,6 +1,6 @@
 import * as tg from "../../TutorialGraph/index"
 import * as tut from "../../Tutorial/Core"
-import { getOrError, getPlayerHero, setUnitPacifist } from "../../util"
+import { freezePlayerHero, getOrError, getPlayerHero, setUnitPacifist } from "../../util"
 import { RequiredState } from "../../Tutorial/RequiredState"
 import { GoalTracker } from "../../Goals"
 
@@ -23,43 +23,45 @@ const onStart = (complete: () => void) => {
     const goalKillDummy = goalTracker.addBoolean("Attack and destroy the target dummy by right-clicking it.")
     const goalKillSunsfan = goalTracker.addBoolean("Attack SUNSfan.")
 
-    graph = tg.withGoals(ctx => goalTracker.getGoals(), tg.seq([
-        // Init
-        tg.wait(1),
+    graph = tg.withGoals(_ => goalTracker.getGoals(), tg.seq([
+        // Unlock player camera and wait for player to move their camera a bit
         tg.setCameraTarget(() => undefined),
-        tg.immediate(_ => getOrError(getPlayerHero()).SetMoveCapability(UnitMoveCapability.GROUND)), // This line can be removed once the movement section is there.
-
-        // Player should move his camera
-        tg.immediate(_ => print("Pre camera movement")),
-        tg.immediate(context => goalMoveCamera.start()),
+        tg.immediate(_ => goalMoveCamera.start()),
         tg.waitForCameraMovement(),
-        tg.immediate(_ => print("Post camera movement")),
-        tg.immediate(context => goalMoveCamera.complete()),
+        tg.immediate(_ => goalMoveCamera.complete()),
+
+        // Lock camera on hero and play some dialog
         tg.textDialog(LocalizationKey.Script_1_Camera_1, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
         tg.setCameraTarget(_ => getOrError(getPlayerHero())),
-        tg.textDialog(LocalizationKey.Script_1_Camera_2, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
+        tg.textDialog(LocalizationKey.Script_1_Camera_2, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 5),
 
-        // Kill target dummy
+        // Spawn dummy and play some dialog about it. Freeze the hero during this and focus camera on the dummy.
+        tg.immediate(_ => freezePlayerHero(true)),
         tg.textDialog(LocalizationKey.Script_1_Camera_3, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+        tg.spawnUnit(CustomNpcKeys.TargetDummy, radiantFountain.GetAbsOrigin().__add(targetDummySpawnOffset), DotaTeam.NEUTRALS, CustomNpcKeys.TargetDummy),
+        tg.setCameraTarget(ctx => ctx[CustomNpcKeys.TargetDummy]),
+        tg.textDialog(LocalizationKey.Script_1_Camera_4, ctx => ctx[CustomNpcKeys.TargetDummy], 3),
+        tg.textDialog(LocalizationKey.Script_1_Camera_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
 
-        tg.fork([
-            tg.seq([
-                tg.textDialog(LocalizationKey.Script_1_Camera_4, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3), // TODO: Make the dummy say this line
-                tg.textDialog(LocalizationKey.Script_1_Camera_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
-            ]),
-            tg.seq([
-                tg.immediate(context => goalKillDummy.start()),
-                tg.spawnAndKillUnit(CustomNpcKeys.TargetDummy, radiantFountain.GetAbsOrigin().__add(targetDummySpawnOffset)),
-                tg.immediate(context => goalKillDummy.complete()),
-            ])
-        ]),
-        tg.textDialog(LocalizationKey.Script_1_Camera_6, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3), // TODO: Make the dummy say this line
+        // Unfreeze the hero and focus the camera on it again.
+        tg.setCameraTarget(_ => getOrError(getPlayerHero())),
+        tg.immediate(_ => freezePlayerHero(false)),
+
+        // Wait for player to kill the dummy
+        tg.immediate(_ => goalKillDummy.start()),
+        tg.completeOnCheck(ctx => !ctx[CustomNpcKeys.TargetDummy] || !IsValidEntity(ctx[CustomNpcKeys.TargetDummy]) || !ctx[CustomNpcKeys.TargetDummy].IsAlive(), 0.2),
+        tg.immediate(_ => goalKillDummy.complete()),
+
+        // Target dummy died dialog
+        tg.textDialog(LocalizationKey.Script_1_Camera_6, ctx => ctx[CustomNpcKeys.TargetDummy], 3),
         tg.textDialog(LocalizationKey.Script_1_Camera_7, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
 
-        // Kill SUNSfan
-        tg.immediate(context => goalKillSunsfan.start()),
+        // MAke SUNSfan attackable
+        tg.immediate(_ => goalKillSunsfan.start()),
         tg.immediate(context => setUnitPacifist(getOrError(context[CustomNpcKeys.SunsFanMudGolem]), false)),
         tg.immediate(context => getOrError(context[CustomNpcKeys.SunsFanMudGolem] as CDOTA_BaseNPC).SetTeam(DotaTeam.NEUTRALS)),
+
+        // Wait for player to kill SUNSfan.
         tg.forkAny([
             // Show a dialog after 10 seconds if the player didn't attack yet encouraging them.
             tg.seq([
@@ -69,12 +71,16 @@ const onStart = (complete: () => void) => {
             ]),
             tg.completeOnCheck(context => {
                 const golem = getOrError(context[CustomNpcKeys.SunsFanMudGolem] as CDOTA_BaseNPC | undefined)
-                return !IsValidEntity(golem) || !golem.IsAlive() || golem.GetHealth() < golem.GetMaxHealth()
+                return !IsValidEntity(golem) || !golem.IsAlive()
             }, 0.2)
         ]),
-        tg.immediate(context => goalKillSunsfan.complete()),
+        tg.immediate(_ => goalKillSunsfan.complete()),
+
+        // Death dialog
         tg.textDialog(LocalizationKey.Script_1_Camera_9, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
         tg.textDialog(LocalizationKey.Script_1_Camera_10, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+
+        // Level up and done
         tg.immediate(_ => getOrError(getPlayerHero()).HeroLevelUp(true)),
         tg.wait(1),
     ]))

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -1,5 +1,5 @@
 import { defaultRequiredState, FilledRequiredState, RequiredState } from "./RequiredState"
-import { findAllPlayersID, getOrError, getPlayerHero } from "../util"
+import { findAllPlayersID, freezePlayerHero, getOrError, getPlayerHero } from "../util"
 
 /**
  * Sets up the state to match the passed state requirement.
@@ -16,6 +16,9 @@ export const setupState = (stateReq: RequiredState): void => {
 
     if (hero.GetCurrentXP() !== state.heroXP || hero.GetUnitName() !== state.heroUnitName) {
         hero = PlayerResource.ReplaceHeroWith(hero.GetPlayerOwner().GetPlayerID(), state.heroUnitName, state.heroGold, state.heroXP)
+    } else {
+        // Make sure the hero is not frozen
+        freezePlayerHero(false)
     }
 
     // Focus all cameras on the hero

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -70,6 +70,16 @@ export function setUnitPacifist(unit: CDOTA_BaseNPC, isPacifist: boolean, durati
 }
 
 /**
+ * Makes the player hero (un-)able to attack and move.
+ * @param frozen Whether or not to freeze the hero.
+ */
+export function freezePlayerHero(frozen: boolean) {
+    const hero = getOrError(getPlayerHero(), "Could not find player hero")
+    setUnitPacifist(hero, frozen)
+    hero.SetMoveCapability(frozen ? UnitMoveCapability.NONE : UnitMoveCapability.GROUND)
+}
+
+/**
  * Freezes time and puts all units into the idle animation. This doesn't literally
  * pause the game, but it effectively does.
  */


### PR DESCRIPTION
- 🇵🇱 camera unlock section
- Added `freezePlayerHero(bool)` which sets pacifist and move capabilities
- Make sure player hero is not frozen (not pacifist and has move capabilities ground) in `setupState()`
- Added `removeOnStop` to `spawnUnit()` which will remove the spawned unit on stop assuming it's still valid.