### PR TITLE
Fix typo causing sunsfan golem to wrongly respawn sometimes

### DIFF
--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -41,7 +41,7 @@ export const setupState = (stateReq: RequiredState): void => {
         clearUnit(CustomNpcKeys.SlacksMudGolem)
     }
 
-    if (state.sunsFanLocation) {
+    if (state.requireSunsfanGolem) {
         createOrMoveUnit(CustomNpcKeys.SunsFanMudGolem, DotaTeam.GOODGUYS, state.sunsFanLocation, state.heroLocation)
     } else {
         clearUnit(CustomNpcKeys.SunsFanMudGolem)


### PR DESCRIPTION
Even if `requireSunsfanGolem` was set to false it would create or move him because of this typo. However the shop ui section currently specifies that the golems are required but doesn't set their location so they spawn in the center (since the default location for them is set to `0, 0`) so that part is unrelated.