### PR TITLE
Fix unit creation in setupState not being complete before starting sections

### DIFF
--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -82,12 +82,11 @@ function createOrMoveUnit(unitName: string, team: DotaTeam, location: Vector, fa
     }
 
     if (!context[unitName] || !IsValidEntity(context[unitName]) || !context[unitName].IsAlive()) {
-        CreateUnitByNameAsync(unitName, location, true, undefined, undefined, team, unit => {
-            if (onCreated) {
-                onCreated(unit)
-            }
-            postCreate(unit)
-        })
+        const unit = CreateUnitByName(unitName, location, true, undefined, undefined, team)
+        if (onCreated) {
+            onCreated(unit)
+        }
+        postCreate(unit)
     } else {
         postCreate(context[unitName])
     }


### PR DESCRIPTION
Before skipping sections `setupState` is called which used `CreateUnitByNameAsync`. The next section got started before the unit was spawned. In this PR `setupState` is changed to use the sync version for creating units instead.