### PR TITLE
Added chapter 1 tree line

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -11,7 +11,7 @@ const requiredState: RequiredState = {
     requireSlacksGolem: true,
     sunsFanLocation: Vector(-6400, -5900, 256),
     slacksLocation: Vector(-6250, -6050, 256),
-    requireTrees: true,
+    requireFountainTrees: true,
 }
 
 const targetDummySpawnOffset = Vector(500, 500, 0)

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -11,6 +11,7 @@ const requiredState: RequiredState = {
     requireSlacksGolem: true,
     sunsFanLocation: Vector(-6400, -5900, 256),
     slacksLocation: Vector(-6250, -6050, 256),
+    requireTrees: true,
 }
 
 const targetDummySpawnOffset = Vector(500, 500, 0)

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCasting.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCasting.ts
@@ -12,6 +12,7 @@ const requiredState: RequiredState = {
     slacksLocation: Vector(-6250, -6050, 256),
     heroLevel: 3,
     heroAbilityMinLevels: [1, 1, 1, 0],
+    requireTrees: true,
 };
 
 const start = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCasting.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCasting.ts
@@ -12,7 +12,7 @@ const requiredState: RequiredState = {
     slacksLocation: Vector(-6250, -6050, 256),
     heroLevel: 3,
     heroAbilityMinLevels: [1, 1, 1, 0],
-    requireTrees: true,
+    requireFountainTrees: true,
 };
 
 const start = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
@@ -11,6 +11,7 @@ const requiredState: RequiredState = {
     slacksLocation: Vector(-6250, -6050, 256),
     requireSunsfanGolem: true,
     heroLevel: 2,
+    requireTrees: true,
 }
 
 const start = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
@@ -11,7 +11,7 @@ const requiredState: RequiredState = {
     slacksLocation: Vector(-6250, -6050, 256),
     requireSunsfanGolem: true,
     heroLevel: 2,
-    requireTrees: true,
+    requireFountainTrees: true,
 }
 
 const start = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
@@ -13,7 +13,7 @@ const requiredState: RequiredState = {
     requireSlacksGolem: true,
     sunsFanLocation: Vector(-6400, -5900, 256),
     slacksLocation: Vector(-6250, -6050, 256),
-    requireTrees: true,
+    requireFountainTrees: true,
 }
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
@@ -13,6 +13,7 @@ const requiredState: RequiredState = {
     requireSlacksGolem: true,
     sunsFanLocation: Vector(-6400, -5900, 256),
     slacksLocation: Vector(-6250, -6050, 256),
+    requireTrees: true,
 }
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
@@ -6,6 +6,7 @@ import { RequiredState } from "../../Tutorial/RequiredState"
 let graph: tg.TutorialStep | undefined = undefined
 let canPlayerIssueOrders = true;
 const requiredState: RequiredState = {
+    requireTrees: true,
 }
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
@@ -6,7 +6,7 @@ import { RequiredState } from "../../Tutorial/RequiredState"
 let graph: tg.TutorialStep | undefined = undefined
 let canPlayerIssueOrders = true;
 const requiredState: RequiredState = {
-    requireTrees: true,
+    requireFountainTrees: true,
 }
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -16,6 +16,7 @@ const requiredState: RequiredState = {
     heroGold: 0,
     heroLevel: 3,
     heroAbilityMinLevels: [1, 1, 1, 0],
+    requireTrees: true,
 };
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -16,7 +16,7 @@ const requiredState: RequiredState = {
     heroGold: 0,
     heroLevel: 3,
     heroAbilityMinLevels: [1, 1, 1, 0],
-    requireTrees: true,
+    requireFountainTrees: true,
 };
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -22,7 +22,7 @@ export type RequiredState = {
     rikiLocation?: Vector
 
     // Chapter 1 trees
-    requireTrees?: boolean
+    requireFountainTrees?: boolean
 }
 
 /**
@@ -53,5 +53,5 @@ export const defaultRequiredState: FilledRequiredState = {
     rikiLocation: GetGroundPosition(Vector(-1500, 4300), undefined),
 
     // Chapter 1 trees
-    requireTrees: false,
+    requireFountainTrees: false,
 }

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -20,6 +20,9 @@ export type RequiredState = {
     // Riki
     requireRiki?: boolean
     rikiLocation?: Vector
+
+    // Chapter 1 trees
+    requireTrees?: boolean
 }
 
 /**
@@ -48,4 +51,7 @@ export const defaultRequiredState: FilledRequiredState = {
     // Riki
     requireRiki: false,
     rikiLocation: GetGroundPosition(Vector(-1500, 4300), undefined),
+
+    // Chapter 1 trees
+    requireTrees: false,
 }

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -110,9 +110,6 @@ export const setupState = (stateReq: RequiredState): void => {
     const treeLocationEnd = Vector(-6300, -6300, 256)
     const getTreeLocation = (alpha: number) => treeLocationStart.__mul(alpha).__add(treeLocationEnd.__mul(1 - alpha))
 
-    // Destroy all trees around the tree-line center point.
-    GridNav.DestroyTreesAroundPoint(getTreeLocation(0.5), 500, true)
-
     // Spawn trees in a line between start and end if we want them.
     if (state.requireTrees) {
         const numTrees = 6
@@ -123,6 +120,9 @@ export const setupState = (stateReq: RequiredState): void => {
                 CreateTempTree(treeLocation, 100000)
             }
         }
+    } else {
+        // Destroy all trees around the tree-line center point.
+        GridNav.DestroyTreesAroundPoint(getTreeLocation(0.5), 500, true)
     }
 }
 

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -111,7 +111,7 @@ export const setupState = (stateReq: RequiredState): void => {
     const getTreeLocation = (alpha: number) => treeLocationStart.__mul(alpha).__add(treeLocationEnd.__mul(1 - alpha))
 
     // Spawn trees in a line between start and end if we want them.
-    if (state.requireTrees) {
+    if (state.requireFountainTrees) {
         const numTrees = 6
         for (let i = 0; i < numTrees; i++) {
             // Only create a tree if there is not already one at the desired location.

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -104,6 +104,26 @@ export const setupState = (stateReq: RequiredState): void => {
     } else {
         clearUnit(CustomNpcKeys.Riki)
     }
+
+    // Chapter 1 tree wall at the fountain
+    const treeLocationStart = Vector(-6800, -5800, 256)
+    const treeLocationEnd = Vector(-6300, -6300, 256)
+    const getTreeLocation = (alpha: number) => treeLocationStart.__mul(alpha).__add(treeLocationEnd.__mul(1 - alpha))
+
+    // Destroy all trees around the tree-line center point.
+    GridNav.DestroyTreesAroundPoint(getTreeLocation(0.5), 500, true)
+
+    // Spawn trees in a line between start and end if we want them.
+    if (state.requireTrees) {
+        const numTrees = 6
+        for (let i = 0; i < numTrees; i++) {
+            // Only create a tree if there is not already one at the desired location.
+            const treeLocation = getTreeLocation(i / (numTrees - 1))
+            if (GridNav.GetAllTreesAroundPoint(treeLocation, 10, true).length === 0) {
+                CreateTempTree(treeLocation, 100000)
+            }
+        }
+    }
 }
 
 function createOrMoveUnit(unitName: string, team: DotaTeam, location: Vector, faceTo?: Vector, onCreated?: (unit: CDOTA_BaseNPC) => void) {


### PR DESCRIPTION
Added the tree line that is supposed to block the player from leaving the fountain in chapter 1 until they eat one of them with a tango to go into chapter 2. Enabled using `requireFountainTrees` on the required state (which is already set here for all sections of chapter 1).

Small (non-?)issue: when we eat the tree and go to chapter 2, the tree line gets destroyed (looks cool I think) as chapter 2 has required set to false.

![image](https://user-images.githubusercontent.com/2614101/110178646-aba7d400-7dfe-11eb-9c49-41395f268ab7.png)
