### PR TITLE
Add chat wheel detection

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -84,6 +84,10 @@ interface RemoveHighlightEvent {
     path: string;
 }
 
+interface ChatWheelPhraseSelectedEvent {
+    phraseIndex: number;
+}
+
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
@@ -104,5 +108,5 @@ interface CustomGameEventDeclarations {
     set_client_clock:ClockTimeEvent
     highlight_element: HighlightElementEvent;
     remove_highlight: RemoveHighlightEvent;
-
+    chat_wheel_phrase_selected: ChatWheelPhraseSelectedEvent;
 }

--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -6,6 +6,7 @@
         <include src="file://{resources}/scripts/custom_game/command-detection.js" />
         <include src="file://{resources}/scripts/custom_game/modifier-key-detection.js" />
         <include src="file://{resources}/scripts/custom_game/time_control.js" />
+        <include src="file://{resources}/scripts/custom_game/chatwheel-detection.js" />
         <!-- <include src="file://{resources}/scripts/custom_game/manifest.js" /> -->
     </scripts>
     <Panel>

--- a/content/panorama/scripts/custom_game/chatwheel-detection.ts
+++ b/content/panorama/scripts/custom_game/chatwheel-detection.ts
@@ -1,0 +1,72 @@
+let wasChatWheelOpen: boolean = false;
+let selectedPhrase: number | undefined;
+
+const numPhrases = 8;
+const updateInterval = 0.01;
+
+(() => {
+    const hudRoot = $.GetContextPanel().GetParent()!.GetParent()!;
+    function findPanelAtPath(path: string): Panel | undefined {
+        const splitPath = path.split("/");
+        let panel = hudRoot;
+        for (let i = 0; i < splitPath.length; i++) {
+            const child = panel.FindChild(splitPath[i]);
+            if (child === null) {
+                return undefined;
+            }
+            panel = child;
+        }
+        return panel;
+    }
+
+    class Lazy<T> {
+        private _value: T | undefined = undefined
+        constructor(private readonly getFn: () => T | undefined) {
+
+        }
+
+        get() {
+            if (this._value === undefined) {
+                this._value = this.getFn();
+            }
+
+            return this._value;
+        }
+    }
+
+    // Lazily get the UI elements because eg. the phrases aren't there until the player opens the chatwheel.
+    const chatWheelLazy = new Lazy<Panel>(() => findPanelAtPath("ChatWheel"));
+    const phrasesLazy: Lazy<Panel>[] = [];
+    for (let i = 0; i < numPhrases; i++) {
+        phrasesLazy.push(new Lazy<Panel>(() => findPanelAtPath(`ChatWheel/PhrasesContainer/Phrase${i}`)));
+    }
+
+    function checkChatWheel() {
+        const chatWheel = chatWheelLazy.get();
+        if (chatWheel) {
+            // Check whether the chat wheel was just closed
+            const isChatWheelOpen = chatWheel.visible;
+            if (wasChatWheelOpen && !isChatWheelOpen && selectedPhrase !== undefined) {
+                GameEvents.SendCustomGameEventToServer("chat_wheel_phrase_selected", { phraseIndex: selectedPhrase });
+            }
+
+            wasChatWheelOpen = isChatWheelOpen;
+
+            // Detect currently selected phrase using class .Selected
+            selectedPhrase = undefined;
+            for (let i = 0; i < numPhrases; i++) {
+                const phrase = phrasesLazy[i].get();
+                if (phrase && phrase.BHasClass("Selected")) {
+                    selectedPhrase = i;
+                    break;
+                }
+            }
+        } else {
+            wasChatWheelOpen = false;
+        }
+
+        $.Schedule(updateInterval, checkChatWheel);
+    }
+
+    $.Schedule(updateInterval, checkChatWheel);
+})();

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -482,6 +482,33 @@ export const waitForModifierKey = (key: ModifierKey) => {
 }
 
 /**
+ * Waits for the player to choose a chat wheel phrase.
+ * @param phraseIndex Optional chat wheel phrase index from 0 to 7 starting at the top going clockwise. If not passed will complete on any index.
+ */
+export const waitForChatWheel = (phraseIndex?: number) => {
+    let listenerId: CustomGameEventListenerID | undefined = undefined
+
+    return tg.step((context, complete) => {
+        listenerId = CustomGameEventManager.RegisterListener("chat_wheel_phrase_selected", (source, event) => {
+            print("Got chat wheel selected", event.phraseIndex)
+            if (phraseIndex === undefined || event.phraseIndex === phraseIndex) {
+                if (listenerId) {
+                    CustomGameEventManager.UnregisterListener(listenerId)
+                    listenerId = undefined
+                }
+
+                complete()
+            }
+        })
+    }, context => {
+        if (listenerId) {
+            CustomGameEventManager.UnregisterListener(listenerId)
+            listenerId = undefined
+        }
+    })
+}
+
+/**
  * Calls a function and completes immediately.
  * @param fn Function to call. Gets passed the context.
  * @param stopFn Optional function to call on stop. Gets passed the context.


### PR DESCRIPTION
Added chat wheel detection so we can see which chat wheel phrase the player selected (currently by index / position, we can get text too although it seems to be already localized so not too helpful in general).

The way it works is we get the chat wheel panel and see when it gets closed. We also check which phrase was last selected (they get a css class `Selected` when they are selected) before the chat wheel was closed to detect which phrase was selected (can be none / undefined too when none was selected).

Also added a corresponding step `waitForChatWheel` for it.

Problems: contains some duplicated code (from `hud.ts`) to find the Dota panels, also the `Lazy` class might be overkill, I just wanted a simple and reliable way to get the panels until they were found.

Fixes https://github.com/ModDota/dota-tutorial/issues/97
