### PR TITLE
Set start game timer to 3s again

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -181,7 +181,7 @@ export class GameMode {
 
         // Start game once pregame hits
         if (state === GameState.PRE_GAME) {
-            Timers.CreateTimer(1, () => this.StartGame());
+            Timers.CreateTimer(3, () => this.StartGame());
         }
 
         if (state === GameState.GAME_IN_PROGRESS) {


### PR DESCRIPTION
1s was too short sometimes and it would cause script errors, should probably think of a better way since 3s might be too short too on bad pcs?