### PR TITLE
fix camera move order being too frequent

### DIFF
--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -288,14 +288,14 @@ export const panCamera = (startLocation: tg.StepArgument<Vector>, endLocation: t
     }
 
     return tg.step((context, complete) => {
-        const updateInterval = FrameTime()
+        const updateInterval = 2 * FrameTime()
         const actualStartLocation = tg.getArg(startLocation, context)
         const actualEndLocation = tg.getArg(endLocation, context)
         const cameraDummy = getCameraDummy(actualStartLocation)
 
         // Focus all cameras on the dummy. Wait one frame for the dummy to have its location set correctly, otherwise
         // we'd see the camera jumping.
-        Timers.CreateTimer(FrameTime(), () => {
+        Timers.CreateTimer(updateInterval, () => {
             // Make sure the camera timer still exists. We might have stopped the panning before this is called.
             if (cameraTimer) {
                 findAllPlayersID().forEach(playerId => PlayerResource.SetCameraTarget(playerId, cameraDummy))

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -198,7 +198,7 @@ export function isCustomLaneCreepUnit(unit: CDOTA_BaseNPC): boolean {
  * @param location Location to spawn the dummy at.
  */
 export function createDummy(location: Vector) {
-    const dummy = CreateUnitByName("npc_dummy_unit", location, false, undefined, undefined, DotaTeam.GOODGUYS)
+    const dummy = CreateUnitByName("npc_dummy_unit", GetGroundPosition(location, undefined), false, undefined, undefined, DotaTeam.GOODGUYS)
     dummy.AddNewModifier(dummy, undefined, "modifier_dummy", {})
     return dummy
 }


### PR DESCRIPTION
with FrameTime() and lower, it would sometimes not move at all. Seems fine with 2 * FrameTime