### PR TITLE
Fix issue with bounty rune creation and removal

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
@@ -95,8 +95,9 @@ function onStart(complete: () => void) {
                     tg.immediate((ctx) => {
                         canPlayerIssueOrders = true
                         goalMoveToRune.start()
-                        if (ctx[CustomEntityKeys.TopPowerRune]) {
+                        if (IsValidEntity(ctx[CustomEntityKeys.TopPowerRune])) {
                             ctx[CustomEntityKeys.TopPowerRune].Destroy()
+                            ctx[CustomEntityKeys.TopPowerRune] = undefined
                         }
                     }),
                 ]),

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -219,19 +219,19 @@ function clearUnit(unitName: string) {
 function createBountyRunes() {
     const context = GameRules.Addon.context
 
-    if (!context[CustomEntityKeys.RadiantTopBountyRune]) {
+    if (!IsValidEntity(context[CustomEntityKeys.RadiantTopBountyRune])) {
         context[CustomEntityKeys.RadiantTopBountyRune] = CreateRune(runeSpawnsLocations.radiantTopBountyPos, RuneType.BOUNTY)
     }
 
-    if (!context[CustomEntityKeys.RadiantAncientsBountyRune]) {
+    if (!IsValidEntity(context[CustomEntityKeys.RadiantAncientsBountyRune])) {
         context[CustomEntityKeys.RadiantAncientsBountyRune] = CreateRune(runeSpawnsLocations.radiantAncientsBountyPos, RuneType.BOUNTY)
     }
 
-    if (!context[CustomEntityKeys.DireBotBountyRune]) {
+    if (!IsValidEntity(context[CustomEntityKeys.DireBotBountyRune])) {
         context[CustomEntityKeys.DireBotBountyRune] = CreateRune(runeSpawnsLocations.direBotBountyPos, RuneType.BOUNTY)
     }
 
-    if (!context[CustomEntityKeys.DireAncientsBountyRune]) {
+    if (!IsValidEntity(context[CustomEntityKeys.DireAncientsBountyRune])) {
         context[CustomEntityKeys.DireAncientsBountyRune] = CreateRune(runeSpawnsLocations.direAncientsBountyPos, RuneType.BOUNTY)
     }
 }
@@ -239,22 +239,22 @@ function createBountyRunes() {
 function removeBountyRunes() {
     const context = GameRules.Addon.context
 
-    if (context[CustomEntityKeys.RadiantTopBountyRune]) {
+    if (IsValidEntity(context[CustomEntityKeys.RadiantTopBountyRune])) {
         context[CustomEntityKeys.RadiantTopBountyRune].Destroy()
         context[CustomEntityKeys.RadiantTopBountyRune] = undefined
     }
 
-    if (context[CustomEntityKeys.RadiantAncientsBountyRune]) {
+    if (IsValidEntity(context[CustomEntityKeys.RadiantAncientsBountyRune])) {
         context[CustomEntityKeys.RadiantAncientsBountyRune].Destroy()
         context[CustomEntityKeys.RadiantAncientsBountyRune] = undefined
     }
 
-    if (context[CustomEntityKeys.DireBotBountyRune]) {
+    if (IsValidEntity(context[CustomEntityKeys.DireBotBountyRune])) {
         context[CustomEntityKeys.DireBotBountyRune].Destroy()
         context[CustomEntityKeys.DireBotBountyRune] = undefined
     }
 
-    if (context[CustomEntityKeys.DireAncientsBountyRune]) {
+    if (IsValidEntity(context[CustomEntityKeys.DireAncientsBountyRune])) {
         context[CustomEntityKeys.DireAncientsBountyRune].Destroy()
         context[CustomEntityKeys.DireAncientsBountyRune] = undefined
     }


### PR DESCRIPTION
- Fix checks for existence or non existence of bounty rune entity stored in context to use IsValidEntity for checking whether a rune exists and can be destroyed or created as necessary since this covers the case of picking up the bounty rune which would mess with it's removal and recreation later
- Add same check for DD rune in Chapter 5 opening section (separate from the setup state code for bounty runes)

Closes #165 