### PR TITLE
Add unit and location highlights

### DIFF
--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -12,7 +12,7 @@ declare const enum SectionName {
     Chapter4_Opening = "Chapter4_Opening",
     Chapter4_Wards = "Chapter4_Wards",
     Chapter4_Outpost = "Chapter4_Outpost",
-    Chapter5_Opening ="Chapter5_Opening",
+    Chapter5_Opening = "Chapter5_Opening",
 }
 
 declare const enum CustomNpcKeys {
@@ -56,4 +56,8 @@ declare const enum ModifierKey {
     Alt,
     Shift,
     Control,
+}
+
+declare const enum ParticleName {
+    HighlightBuilding = "particles/dev/curlnoise_test.vpcf",
 }

--- a/game/scripts/vscripts/Blockade.ts
+++ b/game/scripts/vscripts/Blockade.ts
@@ -49,7 +49,7 @@ export class Blockade {
             this.particle = ParticleManager.CreateParticle(Blockade.blockerParticleName, ParticleAttachment.CUSTOMORIGIN, undefined)
             ParticleManager.SetParticleControl(this.particle, 0, this.startLocation)
             ParticleManager.SetParticleControl(this.particle, 1, this.endLocation)
-            ParticleManager.SetParticleFoWProperties(this.particle, 0, 0, 1000000)
+            ParticleManager.SetParticleFoWProperties(this.particle, 0, 0, 1000)
         }
     }
 

--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -39,6 +39,7 @@ export class GameMode {
 
     public static Precache(this: void, context: CScriptPrecacheContext) {
         PrecacheResource("soundfile", "soundevents/tutorial_dialogs.vsndevts", context);
+        PrecacheResource("particle", ParticleName.HighlightBuilding, context);
     }
 
     public static Activate(this: void) {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
@@ -1,6 +1,6 @@
 import * as tg from "../../TutorialGraph/index"
 import * as tut from "../../Tutorial/Core"
-import { findRealPlayerID, getPlayerHero } from "../../util"
+import { findRealPlayerID, getOrError, getPlayerHero } from "../../util"
 import { RequiredState } from "../../Tutorial/RequiredState"
 import { slacksFountainLocation, slacksInitialLocation, sunsfanFountainLocation } from "./Shared"
 
@@ -43,8 +43,15 @@ const onStart = (complete: () => void) => {
         tg.audioDialog(LocalizationKey.Script_1_Opening_8, LocalizationKey.Script_1_Opening_8, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
         tg.audioDialog(LocalizationKey.Script_1_Opening_9, LocalizationKey.Script_1_Opening_9, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
         tg.panCameraLinear(ctx => ctx[CustomNpcKeys.SlacksMudGolem].GetAbsOrigin(), Entities.FindAllByName("dota_badguys_fort")[0].GetAbsOrigin(), 8),
-        tg.audioDialog(LocalizationKey.Script_1_Opening_10, LocalizationKey.Script_1_Opening_10, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
-        tg.audioDialog(LocalizationKey.Script_1_Opening_11, LocalizationKey.Script_1_Opening_11, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+
+        // Highlight the enemy ancient while talking about it
+        tg.withHighlightUnits(
+            tg.seq([
+                tg.audioDialog(LocalizationKey.Script_1_Opening_10, LocalizationKey.Script_1_Opening_10, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
+                tg.audioDialog(LocalizationKey.Script_1_Opening_11, LocalizationKey.Script_1_Opening_11, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 3),
+            ]),
+            Entities.FindAllByName("dota_badguys_fort") as CDOTA_BaseNPC[]
+        ),
         tg.panCameraExponential(Entities.FindAllByName("dota_badguys_fort")[0].GetAbsOrigin(), _ => playerHero.GetAbsOrigin(), 0.5),
         tg.setCameraTarget(() => playerHero),
     ])

--- a/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
@@ -68,7 +68,7 @@ const onStart = (complete: () => void) => {
                     tg.textDialog(LocalizationKey.Script_2_Opening_2, context => context[CustomNpcKeys.SunsFanMudGolem], 3),
                     tg.textDialog(LocalizationKey.Script_2_Opening_3, context => context[CustomNpcKeys.SlacksMudGolem], 5),
                 ]),
-                Entities.FindAllByClassname("npc_dota_barracks") as CDOTA_BaseNPC[]
+                Entities.FindAllByClassname("npc_dota_filler") as CDOTA_BaseNPC[]
             ),
 
             // Talking about barracks

--- a/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
@@ -61,18 +61,33 @@ const onStart = (complete: () => void) => {
                     canPlayerIssueOrders = false
             }),
             tg.textDialog(LocalizationKey.Script_2_Opening_1, context => context[CustomNpcKeys.SlacksMudGolem], 10),
-            tg.textDialog(LocalizationKey.Script_2_Opening_2, context => context[CustomNpcKeys.SunsFanMudGolem], 3),
-            tg.textDialog(LocalizationKey.Script_2_Opening_3, context => context[CustomNpcKeys.SlacksMudGolem], 5),
-            tg.textDialog(LocalizationKey.Script_2_Opening_4, context => context[CustomNpcKeys.SunsFanMudGolem], 8),
-            tg.textDialog(LocalizationKey.Script_2_Opening_5, context => context[CustomNpcKeys.SlacksMudGolem], 6),
-            tg.textDialog(LocalizationKey.Script_2_Opening_6, context => context[CustomNpcKeys.SunsFanMudGolem], 14),
-            tg.textDialog(LocalizationKey.Script_2_Opening_7, context => context[CustomNpcKeys.SlacksMudGolem], 8),
-            tg.textDialog(LocalizationKey.Script_2_Opening_8, context => context[CustomNpcKeys.SunsFanMudGolem], 12),
-            tg.textDialog(LocalizationKey.Script_2_Opening_9, context => context[CustomNpcKeys.SlacksMudGolem], 12),
+
+            // Talking about moonwells
+            tg.withHighlightUnits(
+                tg.seq([
+                    tg.textDialog(LocalizationKey.Script_2_Opening_2, context => context[CustomNpcKeys.SunsFanMudGolem], 3),
+                    tg.textDialog(LocalizationKey.Script_2_Opening_3, context => context[CustomNpcKeys.SlacksMudGolem], 5),
+                ]),
+                Entities.FindAllByClassname("npc_dota_barracks") as CDOTA_BaseNPC[]
+            ),
+
+            // Talking about barracks
+            tg.withHighlightUnits(
+                tg.seq([
+                    tg.textDialog(LocalizationKey.Script_2_Opening_4, context => context[CustomNpcKeys.SunsFanMudGolem], 8),
+                    tg.textDialog(LocalizationKey.Script_2_Opening_5, context => context[CustomNpcKeys.SlacksMudGolem], 6),
+                    tg.textDialog(LocalizationKey.Script_2_Opening_6, context => context[CustomNpcKeys.SunsFanMudGolem], 14),
+                    tg.textDialog(LocalizationKey.Script_2_Opening_7, context => context[CustomNpcKeys.SlacksMudGolem], 8),
+                    tg.textDialog(LocalizationKey.Script_2_Opening_8, context => context[CustomNpcKeys.SunsFanMudGolem], 12),
+                    tg.textDialog(LocalizationKey.Script_2_Opening_9, context => context[CustomNpcKeys.SlacksMudGolem], 12),
+                ]), Entities.FindAllByClassname("npc_dota_barracks") as CDOTA_BaseNPC[]
+            ),
+
             tg.textDialog(LocalizationKey.Script_2_Opening_10, context => context[CustomNpcKeys.SunsFanMudGolem], 18),
             tg.textDialog(LocalizationKey.Script_2_Opening_11, context => context[CustomNpcKeys.SlacksMudGolem], 5),
             tg.textDialog(LocalizationKey.Script_2_Opening_12, context => context[CustomNpcKeys.SunsFanMudGolem], 3),
             tg.textDialog(LocalizationKey.Script_2_Opening_13, context => context[CustomNpcKeys.SlacksMudGolem], 6),
+
             tg.fork(_ => radiantCreepsNames.map(unit => tg.spawnUnit(unit, radiantCreepsSpawnLocation, DotaTeam.GOODGUYS, undefined, true))),
             tg.fork(_ => direCreepNames.map(unit => tg.spawnUnit(unit, direCreepsSpawnLocation, DotaTeam.BADGUYS, undefined, true))),
             tg.immediate(context => {

--- a/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
@@ -60,14 +60,17 @@ function onStart(complete: () => void) {
 
             tg.wait(1),
 
-            tg.immediate(_ => {
-                CreateItemOnPositionSync(wardLocation, observerWardItem);
-                CreateItemOnPositionSync(wardLocation.__add(Vector(0, 200)), sentryWardItem);
-            }),
+            // Spawn wards and wait for player to pick them up. Also highlight wards during this.
+            tg.withHighlightLocations(tg.seq([
+                tg.immediate(_ => {
+                    CreateItemOnPositionSync(wardLocation, observerWardItem);
+                    CreateItemOnPositionSync(wardLocation.__add(Vector(0, 200)), sentryWardItem);
+                }),
 
-            tg.immediate(_ => goalFetchWard.start()),
+                tg.immediate(_ => goalFetchWard.start()),
 
-            tg.completeOnCheck(_ => playerHero.HasItemInInventory("item_ward_dispenser"), 1),
+                tg.completeOnCheck(_ => playerHero.HasItemInInventory("item_ward_dispenser"), 1),
+            ]), [wardLocation]),
 
             tg.immediate(_ => {
                 goalFetchWard.complete();

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -698,7 +698,8 @@ export const createParticleAtLocation = (particleName: tg.StepArgument<string>, 
         }
 
         particle = ParticleManager.CreateParticle(actualParticleName, ParticleAttachment.CUSTOMORIGIN, undefined)
-        ParticleManager.SetParticleControl(particle, 1, actualLocation)
+        ParticleManager.SetParticleControl(particle, 0, actualLocation)
+        ParticleManager.SetParticleFoWProperties(particle, 0, 0, 1000)
 
         if (actualDuration !== undefined) {
             timer = Timers.CreateTimer(actualDuration, () => {
@@ -743,6 +744,7 @@ export const createParticleAttachedToUnit = (particleName: tg.StepArgument<strin
         }
 
         particle = ParticleManager.CreateParticle(actualParticleName, ParticleAttachment.ABSORIGIN_FOLLOW, actualUnit)
+        ParticleManager.SetParticleFoWProperties(particle, 0, 0, 1000)
 
         if (actualDuration !== undefined) {
             timer = Timers.CreateTimer(actualDuration, () => {
@@ -763,6 +765,54 @@ export const createParticleAttachedToUnit = (particleName: tg.StepArgument<strin
         if (particle) {
             ParticleManager.DestroyParticle(particle, false)
             particle = undefined
+        }
+    })
+}
+
+/**
+ * Executes a step while highlighting the passed units until the step completes.
+ * @param step Step to execute while highlighting.
+ * @param units Units to higlight.
+ */
+export const withHighlightUnits = (step: tg.StepArgument<tg.TutorialStep>, units: tg.StepArgument<CDOTA_BaseNPC[]>) => {
+    let forkStep: tg.TutorialStep | undefined = undefined
+
+    return tg.step((context, complete) => {
+        const actualStep = tg.getArg(step, context)
+        const actualUnits = tg.getArg(units, context)
+
+        const particleSteps = actualUnits.map(unit => createParticleAttachedToUnit(ParticleName.HighlightBuilding, unit))
+
+        forkStep = tg.forkAny([actualStep, ...particleSteps])
+        forkStep.start(context, complete)
+    }, context => {
+        if (forkStep) {
+            forkStep.stop(context)
+            forkStep = undefined
+        }
+    })
+}
+
+/**
+ * Executes a step while highlighting the pased locations until the step completes.
+ * @param step Step to execute while highlighting.
+ * @param locations Locations to highlight.
+ */
+ export const withHighlightLocations = (step: tg.StepArgument<tg.TutorialStep>, locations: tg.StepArgument<Vector[]>) => {
+    let forkStep: tg.TutorialStep | undefined = undefined
+
+    return tg.step((context, complete) => {
+        const actualStep = tg.getArg(step, context)
+        const actualLocations = tg.getArg(locations, context)
+
+        const particleSteps = actualLocations.map(location => createParticleAtLocation(ParticleName.HighlightBuilding, location))
+
+        forkStep = tg.forkAny([actualStep, ...particleSteps])
+        forkStep.start(context, complete)
+    }, context => {
+        if (forkStep) {
+            forkStep.stop(context)
+            forkStep = undefined
         }
     })
 }

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -798,7 +798,7 @@ export const withHighlightUnits = (step: tg.StepArgument<tg.TutorialStep>, units
  * @param step Step to execute while highlighting.
  * @param locations Locations to highlight.
  */
- export const withHighlightLocations = (step: tg.StepArgument<tg.TutorialStep>, locations: tg.StepArgument<Vector[]>) => {
+export const withHighlightLocations = (step: tg.StepArgument<tg.TutorialStep>, locations: tg.StepArgument<Vector[]>) => {
     let forkStep: tg.TutorialStep | undefined = undefined
 
     return tg.step((context, complete) => {


### PR DESCRIPTION
- Added `withHighlightUnits` and `withHighlightLocations` which wrap a step and highlights things until the step completes
- Added highlights to chapter 1 opening enemy ancient
- Added highlights to chapter 2 opening buildings
- Added highlights to chapter 4 opening wards
- Reduced the fog of war visibility range for particles (previously was spam-complaining in console about it being too big)

![image](https://user-images.githubusercontent.com/2614101/110258122-bbf3b680-7f98-11eb-802b-aef1fc9d005e.png)