### PR TITLE
Highlight animation

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -40,7 +40,7 @@ interface ClockTimeEvent {
 interface HighlightElementEvent {
     path: string;
     duration?: number;
-    setElementAsParent?: 0 | 1;
+    setElementAsParent?: boolean;
 }
 
 interface RemoveHighlightEvent {

--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -66,6 +66,7 @@ interface ClockTimeEvent {
 interface HighlightElementEvent {
     path: string;
     duration?: number;
+    setElementAsParent?: 0 | 1;
 }
 
 interface RemoveHighlightEvent {

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -48,7 +48,7 @@ function findPanelAtPath(path: string): Panel | undefined {
     const splitPath = path.split("/");
     let panel = hudRoot;
     for (let i = 0; i < splitPath.length; i++) {
-        const child = panel.FindChild(splitPath[i]);
+        const child = panel.FindChildTraverse(splitPath[i]);
         if (child === null) {
             $.Msg(`Failed to find ${splitPath[i]} in ${splitPath.slice(0, i).join("/")}`);
             return undefined;
@@ -71,7 +71,7 @@ function removeHighlight(event: RemoveHighlightEvent) {
 //highlightUiElement("HUDElements/lower_hud/center_with_stats/center_block/PortraitGroup");
 //highlightUiElement("HUDElements/lower_hud/center_with_stats/center_block/inventory");
 function highlightUiElement(event: HighlightElementEvent) {
-    const { path, duration } = event;
+    const { path, duration, setElementAsParent } = event;
     // Panel is already highlighted
     if (highlightedPanels[path]) {
         $.Msg("Element is already highlighted");
@@ -84,7 +84,8 @@ function highlightUiElement(event: HighlightElementEvent) {
         const parent = element.GetParent()!;
 
         const highlightPanel = $.CreatePanel("Panel", $.GetContextPanel(), "UIHighlight");
-        highlightPanel.SetParent(parent);
+        if (setElementAsParent) highlightPanel.SetParent(element);
+        else highlightPanel.SetParent(parent);
 
         highlightPanel.AddClass("UIHighlight");
 

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -70,7 +70,7 @@ function removeHighlight(event: RemoveHighlightEvent) {
 
 //highlightUiElement("HUDElements/lower_hud/center_with_stats/center_block/PortraitGroup");
 //highlightUiElement("HUDElements/lower_hud/center_with_stats/center_block/inventory");
-function highlightUiElement(event: HighlightElementEvent) {
+function highlightUiElement(event: NetworkedData<HighlightElementEvent>) {
     const { path, duration, setElementAsParent } = event;
     // Panel is already highlighted
     if (highlightedPanels[path]) {

--- a/content/panorama/styles/custom_game/hud.css
+++ b/content/panorama/styles/custom_game/hud.css
@@ -5,10 +5,28 @@
 
 .UIHighlight {
     z-index: 100;
-    border-width: 5px;
-    border-color: yellow;
-    border-style: solid;
-    box-shadow: yellow 0px 0px 10px 0px;
+    animation-name: glow;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+}
+
+@keyframes 'glow' {
+    0% {
+        box-shadow: 0 0 5px gold;
+    }
+    25% {
+        box-shadow: 0 0 10px gold;
+    }
+    50% {
+        box-shadow: 0 0 20px gold;
+    }
+    75% {
+        box-shadow: 0 0 10px gold;
+    }
+    100% {
+        box-shadow: 0 0 5px gold;
+    }
 }
 
 #ChaptersMenu {
@@ -44,7 +62,7 @@
 
     text-transform: uppercase;
     color: #ffffffdd;
-    text-shadow: 0px 0px 20px 1.0 #3382ff44;
+    text-shadow: 0px 0px 20px 1 #3382ff44;
     font-weight: bold;
     font-size: 25px;
     letter-spacing: 2px;
@@ -55,7 +73,7 @@
     horizontal-align: right;
     width: 30px;
     height: 30px;
-    
+
     background-size: 100%;
     background-color: #444;
     background-image: url("file://{images}/custom_game/skip_section/close_icon.png");
@@ -84,7 +102,7 @@
 .ChapterContainer {
     height: 340px;
     width: 188px;
-    
+
     margin-left: 10px;
     margin-top: 10px;
     border-top-left-radius: 5px;
@@ -184,7 +202,7 @@
     align: center top;
     text-transform: uppercase;
     color: #ffffffdd;
-    text-shadow: 0px 0px 20px 1.0 #3382ff44;
+    text-shadow: 0px 0px 20px 1 #3382ff44;
     font-weight: bold;
     font-size: 20px;
     letter-spacing: 2px;

--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -1,7 +1,7 @@
 import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
-import { displayDotaErrorMessage, findRealPlayerID, getPlayerHero, isShopOpen } from "../../util";
+import { displayDotaErrorMessage, findRealPlayerID, getPlayerHero, highlightUiElement, isShopOpen, removeHighlight } from "../../util";
 import { GoalTracker } from "../../Goals";
 
 const sectionName: SectionName = SectionName.Chapter1_ShopUI;
@@ -26,6 +26,9 @@ const onStart = (complete: () => void) => {
     const playerHero = getPlayerHero();
     if (!playerHero) error("Could not find the player's hero.");
 
+    const shopBtnUIPath = "HUDElements/lower_hud/shop_launcher_block/ShopCourierControls/ShopButton"
+    const tangoInGuideUIPath = "HUDElements/shop/GuideFlyout/ItemsArea/ItemBuildContainer/ItemBuild/Categories/ItemList/Item44"
+
     const goalTracker = new GoalTracker();
     const goalOpenShop = goalTracker.addBoolean("Open the shop.");
     const goalBuyTango = goalTracker.addBoolean("Use the gold provided to purchase a Tango.");
@@ -37,20 +40,25 @@ const onStart = (complete: () => void) => {
 
     graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
+            tg.wait(FrameTime()),
             tg.immediate(_ => {
                 goalOpenShop.start();
                 playerHero.SetGold(90, true);
+                highlightUiElement(shopBtnUIPath)
                 waitingForPlayerToPurchaseTango = true;
             }),
             tg.completeOnCheck(_ => isShopOpen(), 0.1),
             tg.immediate(_ => {
                 goalOpenShop.complete();
                 goalBuyTango.start();
+                highlightUiElement(tangoInGuideUIPath, undefined, true);
             }),
             tg.completeOnCheck(_ => {
                 return playerBoughtTango;
             }, 0.2),
             tg.immediate(_ => {
+                removeHighlight(shopBtnUIPath);
+                removeHighlight(tangoInGuideUIPath);
                 goalBuyTango.complete();
                 goalEatTree.start();
             }),

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -154,9 +154,7 @@ export function displayDotaErrorMessage(message: string) {
  * @param setElementAsParent Optional. Sets the element provided in the path as the parent, instead of as a sibling. Used for cases where the parent has the flow-children CSS property.
  */
 export function highlightUiElement(path: string, duration?: number, setElementAsParent?: boolean) {
-    let eventSetElementAsParent: 0 | 1
-    eventSetElementAsParent = setElementAsParent ? 1 : 0
-    CustomGameEventManager.Send_ServerToAllClients("highlight_element", { path, duration, setElementAsParent: eventSetElementAsParent });
+    CustomGameEventManager.Send_ServerToAllClients("highlight_element", { path, duration, setElementAsParent });
 }
 
 /**

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -151,9 +151,12 @@ export function displayDotaErrorMessage(message: string) {
  * Highlights a panel along a path
  * @param path The path along the ui to take, such as "HUDElements/lower_hud/center_with_stats/center_block/inventory"
  * @param duration Optional time in seconds after which to remove the highlight
+ * @param setElementAsParent Optional. Sets the element provided in the path as the parent, instead of as a sibling. Used for cases where the parent has the flow-children CSS property.
  */
-export function highlightUiElement(path: string, duration?: number) {
-    CustomGameEventManager.Send_ServerToAllClients("highlight_element", { path, duration });
+export function highlightUiElement(path: string, duration?: number, setElementAsParent?: boolean) {
+    let eventSetElementAsParent: 0 | 1
+    eventSetElementAsParent = setElementAsParent ? 1 : 0
+    CustomGameEventManager.Send_ServerToAllClients("highlight_element", { path, duration, setElementAsParent: eventSetElementAsParent });
 }
 
 /**


### PR DESCRIPTION
- Adds a highlight animation that glows on and off while the UI is being highlighted. Note: because Valve can't do CSS properties right, the @keyframes property will throw errors at you if you have the CSS linter on. I could not find a way to fix that. Super annoying.
- Added an optional parameter to set the new highlight panel as the parent rather as a sibling. Optional, defaults to false.
- Changed `FindChild` to `FindChildTraverse` when crawling through the path, as sometimes providing the full path is not possible (due to classes and/or varying IDs, like when checking for the Tango's guide)
- Added highlighting on the Shop UI section for buying a Tango.