### PR TITLE
Fix goToLocation particle persisting

### DIFF
--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -38,6 +38,8 @@ export const goToLocation = (location: tg.StepArgument<Vector>) => {
     }, context => {
         if (checkTimer) {
             Timers.RemoveTimer(checkTimer)
+            const actualLocation = tg.getArg(location, context)
+            MinimapEvent(DotaTeam.GOODGUYS, getPlayerHero() as CBaseEntity, actualLocation.x, actualLocation.y, MinimapEventType.TUTORIAL_TASK_FINISHED, 0.1);
             checkTimer = undefined
         }
     })


### PR DESCRIPTION
This fixes the issue where the Go To Location particle wouldn't disappear when skipping a section while it is on the goToLocation step by removing it when stopping.