### PR TITLE
Fix remove time callback

### DIFF
--- a/game/scripts/vscripts/TimeManager.ts
+++ b/game/scripts/vscripts/TimeManager.ts
@@ -48,7 +48,9 @@ export class CustomTimeManager {
     }
 
     unregisterCallBackOnTime(index: number) {
-        if (this.callbacks.has(index)) {
+        // Didn't seem like this worked with has() (maybe tstl bug) so using get() instead.
+        const callback = this.callbacks.get(index);
+        if (callback) {
             this.callbacks.delete(index);
         }
     }


### PR DESCRIPTION
Fixes not being able to eg. skip in Ch3.

`.has()` gave an error (probably TSTL bug)

```
scripts\vscripts\lualib_bundle.lua:881: table index is nil
	scripts\vscripts\lualib_bundle.lua:881: in function 'delete'
	scripts\vscripts\TimeManager.ts:52: in function 'unregisterCallBackOnTime'
	scripts\vscripts\Sections/Chapter3/Chapter3.ts:350: in function 'onStop'
	scripts\vscripts\Tutorial/Core.ts:96: in function 'start'
	scripts\vscripts\Tutorial/Core.ts:132: in function 'startBySectionName'
	scripts\vscripts\GameMode.ts:65: in function <scripts\vscripts\GameMode.lua:42>
Script Runtime Error: scripts\vscripts\lualib_bundle.lua:881: table index is nil
stack traceback:
	[C]: in function '__newindex'
	scripts\vscripts\lualib_bundle.lua:881: in function 'delete'
	scripts\vscripts\TimeManager.ts:52: in function 'unregisterCallBackOnTime'
	scripts\vscripts\Sections/Chapter3/Chapter3.ts:350: in function 'onStop'
	scripts\vscripts\Tutorial/Core.ts:96: in function 'start'
	scripts\vscripts\Tutorial/Core.ts:132: in function 'startBySectionName'
	scripts\vscripts\GameMode.ts:65: in function <scripts\vscripts\GameMode.lua:42>
```

Using `.get()` and checking for `undefined` seems to work.