### PR TITLE
Add camera lock to required state

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -26,8 +26,6 @@ const onStart = (complete: () => void) => {
     const goalKillSunsfan = goalTracker.addBoolean("Attack SUNSfan.")
 
     graph = tg.withGoals(_ => goalTracker.getGoals(), tg.seq([
-        // Unlock player camera and wait for player to move their camera a bit
-        tg.setCameraTarget(() => undefined),
         tg.immediate(_ => goalMoveCamera.start()),
         tg.waitForCameraMovement(),
         tg.immediate(_ => goalMoveCamera.complete()),

--- a/game/scripts/vscripts/Sections/Chapter1/SectionCasting.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCasting.ts
@@ -14,6 +14,7 @@ const requiredState: RequiredState = {
     heroLevel: 3,
     heroAbilityMinLevels: [1, 1, 1, 0],
     requireFountainTrees: true,
+    lockCameraOnHero: true,
 };
 
 const start = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
@@ -13,6 +13,7 @@ const requiredState: RequiredState = {
     slacksLocation: slacksFountainLocation,
     heroLevel: 2,
     requireFountainTrees: true,
+    lockCameraOnHero: true,
 }
 
 const pugnaLocation = Vector(-6700, -6300, 384)

--- a/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
@@ -14,6 +14,7 @@ const requiredState: RequiredState = {
     sunsFanLocation: sunsfanFountainLocation,
     slacksLocation: slacksFountainLocation,
     requireFountainTrees: true,
+    lockCameraOnHero: true,
 }
 
 const onStart = (complete: () => void) => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionOpening.ts
@@ -12,6 +12,7 @@ const requiredState: RequiredState = {
     slacksLocation: slacksInitialLocation,
     sunsFanLocation: sunsfanFountainLocation,
     requireFountainTrees: true,
+    lockCameraOnHero: true,
 }
 
 const onStart = (complete: () => void) => {
@@ -20,7 +21,6 @@ const onStart = (complete: () => void) => {
 
     graph = tg.seq([
         tg.immediate(() => canPlayerIssueOrders = false),
-        tg.setCameraTarget(() => playerHero),
         tg.fork([
             tg.seq([
                 tg.moveUnit(context => context[CustomNpcKeys.SlacksMudGolem], slacksFountainLocation),
@@ -57,7 +57,7 @@ const onStart = (complete: () => void) => {
             }
         ),
         tg.panCameraExponential(Entities.FindAllByName("dota_badguys_fort")[0].GetAbsOrigin(), _ => playerHero.GetAbsOrigin(), 0.5),
-        tg.setCameraTarget(() => playerHero),
+        tg.setCameraTarget(playerHero),
     ])
 
     graph.start(GameRules.Addon.context, () => {

--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -16,6 +16,7 @@ const requiredState: RequiredState = {
     heroLevel: 3,
     heroAbilityMinLevels: [1, 1, 1, 0],
     requireFountainTrees: true,
+    lockCameraOnHero: true,
 };
 
 let waitingForPlayerToPurchaseTango = false;
@@ -134,7 +135,6 @@ const onStart = (complete: () => void) => {
                     tg.immediate(_ => blockadeRadiantBaseMid.spawn()),
                     tg.wait(1.5),
                     tg.panCameraExponential(middleMidPoint, _ => playerHero.GetAbsOrigin(), 4),
-                    tg.setCameraTarget(undefined),
                 ])
             ]),
 

--- a/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
@@ -61,7 +61,6 @@ const onStart = (complete: () => void) => {
     graph = tg.withGoals(context => goalTracker.getGoals(),
         tg.seq([
             tg.wait(FrameTime()),
-            tg.setCameraTarget(undefined),
             tg.immediate(context => {
                 goalMoveNextToBarracks.start(),
                     freezePlayerHero(false)

--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -5,7 +5,7 @@ import { modifier_nodamage_chapter2_tower } from "../../modifiers/modifier_nodam
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPlayerHero, highlightUiElement, removeContextEntityIfExists, removeHighlight, setUnitPacifist } from "../../util";
+import { centerCameraOnHero, displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPlayerHero, highlightUiElement, removeContextEntityIfExists, removeHighlight, setUnitPacifist } from "../../util";
 import { chapter2Blockades, Chapter2SpecificKeys, radiantCreepsNames } from "./shared";
 
 const sectionName: SectionName = SectionName.Chapter2_Tower
@@ -83,10 +83,7 @@ const onStart = (complete: () => void) => {
 
     graph = tg.withGoals(context => goalTracker.getGoals(),
         tg.seq([
-            tg.wait(FrameTime()),
-            tg.setCameraTarget(playerHero),
-            tg.wait(FrameTime()),
-            tg.setCameraTarget(undefined),
+            tg.immediate(_ => centerCameraOnHero()),
             tg.immediate(context => {
                 freezePlayerHero(true);
                 playerMustOrderTrainUltimate = false;

--- a/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
@@ -3,7 +3,7 @@ import { isShopOpen } from "../../Shop";
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPathToItemInGuideByID, getPlayerHero, highlightUiElement, removeHighlight } from "../../util";
+import { centerCameraOnHero, displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPathToItemInGuideByID, getPlayerHero, highlightUiElement, removeHighlight } from "../../util";
 import { chapter2Blockades } from "./shared";
 import { modifier_courier_chapter_2_ms_bonus } from "../../modifiers/modifier_courier_chapter_2_ms_bonus";
 
@@ -90,10 +90,7 @@ const onStart = (complete: () => void) => {
     const goalMoveToFinalPosition = goalTracker.addBoolean("Move into the Dire jungle.")
 
     graph = tg.withGoals(context => goalTracker.getGoals(), tg.seq([
-        tg.wait(FrameTime()),
-        tg.setCameraTarget(playerHero),
-        tg.wait(FrameTime()),
-        tg.setCameraTarget(undefined),
+        tg.immediate(_ => centerCameraOnHero()),
         tg.immediate(() => freezePlayerHero(true)),
         tg.audioDialog(LocalizationKey.Script_2_Courier_1, LocalizationKey.Script_2_Courier_1, context => context[CustomNpcKeys.SlacksMudGolem]),
         tg.audioDialog(LocalizationKey.Script_2_Courier_2, LocalizationKey.Script_2_Courier_2, context => context[CustomNpcKeys.SunsFanMudGolem]),

--- a/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
@@ -144,8 +144,9 @@ function onStart(complete: () => void) {
             tg.immediate(context => context[kunkkaName].StartGesture(GameActivity.DOTA_GENERIC_CHANNEL_1)),
             tg.moveUnit(context => context[kunkkaName], allyHeroStartLocation),
             tg.immediate(context => context[kunkkaName].FadeGesture(GameActivity.DOTA_GENERIC_CHANNEL_1)),
+
             tg.immediate(_ => freezePlayerHero(false)),
-            tg.setCameraTarget(playerHero),
+            tg.setCameraTarget(undefined),
 
             tg.audioDialog(LocalizationKey.Script_4_Communication_16, LocalizationKey.Script_4_Communication_16, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             tg.audioDialog(LocalizationKey.Script_4_Communication_17, LocalizationKey.Script_4_Communication_17, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),

--- a/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
@@ -2,7 +2,7 @@ import * as tg from "../../TutorialGraph/index";
 import * as tut from "../../Tutorial/Core";
 import * as shared from "./Shared"
 import * as dg from "../../Dialog"
-import { displayDotaErrorMessage, findRealPlayerID, getOrError, getPlayerHero, unitIsValidAndAlive, highlightUiElement, removeHighlight } from "../../util";
+import { displayDotaErrorMessage, findRealPlayerID, getOrError, getPlayerHero, unitIsValidAndAlive, highlightUiElement, removeHighlight, centerCameraOnHero } from "../../util";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
 import { TutorialContext } from "../../TutorialGraph/index";
@@ -55,9 +55,6 @@ function onStart(complete: () => void) {
 
     graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
-            tg.setCameraTarget(playerHero),
-            tg.wait(2),
-
             tg.audioDialog(LocalizationKey.Script_4_Opening_1, LocalizationKey.Script_4_Opening_1, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             tg.audioDialog(LocalizationKey.Script_4_Opening_2, LocalizationKey.Script_4_Opening_2, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
             //Part0: The camera pans to an empty part of the map
@@ -81,7 +78,9 @@ function onStart(complete: () => void) {
                 tg.audioDialog(LocalizationKey.Script_4_Opening_4, LocalizationKey.Script_4_Opening_4, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
             ]),
 
-            tg.setCameraTarget(playerHero),
+            tg.setCameraTarget(undefined),
+            tg.immediate(_ => centerCameraOnHero()),
+
             tg.audioDialog(LocalizationKey.Script_4_Opening_5, LocalizationKey.Script_4_Opening_5, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             tg.audioDialog(LocalizationKey.Script_4_Opening_6, LocalizationKey.Script_4_Opening_6, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
             tg.immediate(_ => {
@@ -113,7 +112,9 @@ function onStart(complete: () => void) {
                 ])
             ]),
 
-            tg.setCameraTarget(playerHero),
+            tg.setCameraTarget(undefined),
+            tg.immediate(_ => centerCameraOnHero()),
+
             tg.immediate(_ => disposeHeroes()),
             tg.immediate(_ => goalWatchJuke.complete()),
 

--- a/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
@@ -70,7 +70,6 @@ function onStart(complete: () => void) {
 
     graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
-            tg.setCameraTarget(playerHero),
             tg.immediate(_ => setUnitPacifist(playerHero, true)),
             tg.fork(invisHeroInfo.map(hero => tg.spawnUnit(hero.name, hero.loc, DotaTeam.BADGUYS, hero.name, true))),
 

--- a/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
@@ -2,7 +2,7 @@ import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
-import { findRealPlayerID, getOrError, getPlayerHero } from "../../util";
+import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerHero } from "../../util";
 import { chapter5Blockades, runeSpawnsLocations } from "./Shared";
 
 const sectionName: SectionName = SectionName.Chapter5_Opening;
@@ -91,7 +91,8 @@ function onStart(complete: () => void) {
                 tg.seq([
                     tg.panCameraLinear(playerHero.GetAbsOrigin(), runeSpawnsLocations.topPowerUpRunePos, 2),
                     tg.wait(1),
-                    tg.setCameraTarget(playerHero),
+                    tg.setCameraTarget(undefined),
+                    tg.immediate(_ => centerCameraOnHero()),
                     tg.immediate((ctx) => {
                         canPlayerIssueOrders = true
                         goalMoveToRune.start()
@@ -114,7 +115,7 @@ function onStart(complete: () => void) {
                 ctx[CustomEntityKeys.TopPowerRune] = CreateRune(runeSpawnsLocations.topPowerUpRunePos, RuneType.DOUBLEDAMAGE)
             }),
             tg.wait(1),
-            tg.setCameraTarget(playerHero),
+            tg.immediate(_ => centerCameraOnHero()),
             tg.textDialog(LocalizationKey.Script_5_Opening_10, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 2),
             tg.immediate(ctx => {
                 canPlayerIssueOrders = true

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -3,7 +3,7 @@ import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
 import { chapter5Blockades, runeSpawnsLocations } from "./Shared";
-import { findRealPlayerID, getOrError, getPlayerHero, setUnitPacifist, unitIsValidAndAlive } from "../../util";
+import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerHero, setUnitPacifist, unitIsValidAndAlive } from "../../util";
 import { modifier_custom_roshan_attack_speed } from "../../modifiers/modifier_custom_roshan_attack_speed";
 
 const sectionName: SectionName = SectionName.Chapter5_Roshan;
@@ -104,9 +104,8 @@ function onStart(complete: () => void) {
                     tg.panCameraLinear(playerHero.GetOrigin(), roshPitGoalPosition, 2),
                     tg.wait(2),
                     tg.immediate(() => canPlayerIssueOrders = true),
-                    tg.setCameraTarget(playerHero),
-                    tg.wait(1),
                     tg.setCameraTarget(undefined),
+                    tg.immediate(_ => centerCameraOnHero()),
                 ]),
             ]),
             tg.immediate(() => goalEnterRoshPit.complete()),
@@ -161,9 +160,8 @@ function onStart(complete: () => void) {
             }),
             tg.setCameraTarget(context => context[friendlyHeroesInfo[0].name]),
             tg.wait(1),
-            tg.setCameraTarget(playerHero),
-            tg.wait(1),
             tg.setCameraTarget(undefined),
+            tg.immediate(_ => centerCameraOnHero()),
             tg.audioDialog(LocalizationKey.Script_5_Roshan_6, LocalizationKey.Script_5_Roshan_6, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             tg.completeOnCheck(() => {
                 return !roshan.IsAlive()

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -11,10 +11,13 @@ export type RequiredState = {
     heroLocation?: Vector
     heroLocationTolerance?: number // How far the hero can be from heroLocation without getting teleported
     heroGold?: number
-    heroAbilityMinLevels?: [number, number, number, number],
-    heroItems?: Record<string, number>, // Items (and how many of them) the hero must have in his inventory.
-    removeUnrequiredItems?: boolean,  // If true, remove any items not specified in heroItems. (Default true)
+    heroAbilityMinLevels?: [number, number, number, number]
+    heroItems?: Record<string, number> // Items (and how many of them) the hero must have in his inventory.
+    removeUnrequiredItems?: boolean  // If true, remove any items not specified in heroItems. (Default true)
     heroHasDoubleDamage?: boolean
+
+    // Camera
+    lockCameraOnHero?: boolean
 
     // Golems
     requireSunsfanGolem?: boolean
@@ -58,6 +61,9 @@ export const defaultRequiredState: FilledRequiredState = {
     heroItems: {},
     removeUnrequiredItems: true,
     heroHasDoubleDamage: false,
+
+    // Camera
+    lockCameraOnHero: false,
 
     // Golems
     requireSunsfanGolem: false,

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -46,6 +46,9 @@ function handleMisc(state: FilledRequiredState, hero: CDOTA_BaseNPC_Hero) {
     } else {
         removeBountyRunes()
     }
+
+    // Focus or unlock all cameras
+    findAllPlayersID().forEach(playerId => PlayerResource.SetCameraTarget(playerId, state.lockCameraOnHero ? hero : undefined))
 }
 
 function handleFountainTrees(state: FilledRequiredState) {
@@ -140,10 +143,6 @@ function handleHeroCreationAndLevel(state: FilledRequiredState): CDOTA_BaseNPC_H
     // Level the hero to the desired level. 1 experience per level as defined in GameMode.
     hero.AddExperience(state.heroLevel - hero.GetLevel(), ModifyXpReason.UNSPECIFIED, false, false)
 
-    // Focus all cameras on the hero
-    const playerIds = findAllPlayersID()
-    playerIds.forEach(playerId => PlayerResource.SetCameraTarget(playerId, hero))
-
     // Move the hero if not within tolerance
     if (state.heroLocation.__sub(hero.GetAbsOrigin()).Length2D() > state.heroLocationTolerance) {
         hero.Stop()
@@ -192,12 +191,12 @@ function handleRequiredAbilities(state: FilledRequiredState, hero: CDOTA_BaseNPC
     if (state.heroHasDoubleDamage) {
         if (!hero.HasModifier("modifier_rune_doubledamage")) {
             hero.AddNewModifier(hero, undefined, "modifier_rune_doubledamage", {
-                // Have to explicitly set duration or it assumes infinite, using standard value as of dota patch 7.28c                
+                // Have to explicitly set duration or it assumes infinite, using standard value as of dota patch 7.28c
                 duration: 45
             })
         }
     }
-    
+
     // Set remaining ability points. Print a warning if we made an obvious mistake (eg. sum of minimum levels > hero level) but allow it.
     remainingAbilityPoints = getRemainingAbilityPoints()
     if (remainingAbilityPoints < 0) {

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -458,6 +458,9 @@ export function clearAttachedHighlightParticlesFromUnits(units: CDOTA_BaseNPC[])
     }
 }
 
+/**
+ * Centers the camera on the player's hero. Does not lock the camera.
+ */
 export function centerCameraOnHero() {
     const playerHero = getOrError(getPlayerHero(), "Could not get player hero");
     CenterCameraOnUnit(playerHero.GetPlayerOwnerID(), playerHero);

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -335,7 +335,7 @@ export const createParticleAtLocation = (particleName: string, location: Vector)
  * @param attachPoint Optional parameter for where and how to attach the particle.
  * @returns The created particle.
  */
- export const createParticleAttachedToUnit = (particleName: string, unit: CDOTA_BaseNPC, attach: ParticleAttachment = ParticleAttachment.ABSORIGIN_FOLLOW) => {
+export const createParticleAttachedToUnit = (particleName: string, unit: CDOTA_BaseNPC, attach: ParticleAttachment = ParticleAttachment.ABSORIGIN_FOLLOW) => {
     const particleID = ParticleManager.CreateParticle(particleName, attach, unit)
     const modifier = unit.AddNewModifier(undefined, undefined, "modifier_particle_attach", {})
     if (modifier) {
@@ -454,4 +454,9 @@ export function clearAttachedHighlightParticlesFromUnits(units: CDOTA_BaseNPC[])
             }
         }
     }
+}
+
+export function centerCameraOnHero() {
+    const playerHero = getOrError(getPlayerHero(), "Could not get player hero");
+    CenterCameraOnUnit(playerHero.GetPlayerOwnerID(), playerHero);
 }


### PR DESCRIPTION
- Added `lockCameraOnHero` (default `false`) to `RequiredState`
- Replaced `setCameraTarget(hero ->  undefined)` used for centering on hero with dota function call
- CH1 locked on hero, afterwards unlocked