### PR TITLE
Required state respawn

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
@@ -30,7 +30,7 @@ const requiredState: RequiredState = {
         chapter2Blockades.direTopDividerCliff
     ],
     respawnLocation: Vector(-6270, 2722, 128),
-    respawnTime: 5
+    respawnTime: 5,
 }
 
 let lastHitTimer: string | undefined;

--- a/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
@@ -28,7 +28,9 @@ const requiredState: RequiredState = {
         chapter2Blockades.radiantBaseBottom,
         chapter2Blockades.direTopDividerRiver,
         chapter2Blockades.direTopDividerCliff
-    ]
+    ],
+    respawnLocation: Vector(-6270, 2722, 128),
+    respawnTime: 5
 }
 
 let lastHitTimer: string | undefined;

--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -2,10 +2,11 @@ import { GoalTracker } from "../../Goals";
 import { modifier_dk_attack_tower_chapter2 } from "../../modifiers/modifier_dk_attack_tower_chapter2";
 import { modifier_dk_death_chapter2_tower } from "../../modifiers/modifier_dk_death_chapter2_tower";
 import { modifier_nodamage_chapter2_tower } from "../../modifiers/modifier_nodamage_chapter2_tower";
+import { getSoundDuration } from "../../Sounds";
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPlayerHero, highlightUiElement, removeContextEntityIfExists, removeHighlight, setUnitPacifist } from "../../util";
+import { displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPlayerHero, highlightUiElement, removeContextEntityIfExists, removeHighlight, setRespawnSettings, setUnitPacifist } from "../../util";
 import { chapter2Blockades, Chapter2SpecificKeys, radiantCreepsNames } from "./shared";
 
 const sectionName: SectionName = SectionName.Chapter2_Tower
@@ -17,6 +18,7 @@ let playerMustOrderGlyph = false
 let hasPlayerOrderedGlyphWhenMust = false
 let playerOrderMustCastUltimate = false
 let radiantCreepTimer: string | undefined;
+const deathConversations = [LocalizationKey.Script_2_Tower_3, LocalizationKey.Script_2_Tower_4, LocalizationKey.Script_2_Tower_5, LocalizationKey.Script_2_Tower_6]
 
 const requiredState: RequiredState = {
     heroLocation: Vector(-6130, 4860, 128),
@@ -37,6 +39,8 @@ const requiredState: RequiredState = {
         chapter2Blockades.direTopDividerRiver,
         chapter2Blockades.direTopDividerCliff
     ],
+    respawnLocation: Vector(-6130, 4860, 128),
+    respawnTime: 5
 }
 
 // UI Highlighting Paths
@@ -102,6 +106,9 @@ const onStart = (complete: () => void) => {
             tg.audioDialog(LocalizationKey.Script_2_Tower_1, LocalizationKey.Script_2_Tower_1, context => context[CustomNpcKeys.SlacksMudGolem]),
             tg.audioDialog(LocalizationKey.Script_2_Tower_2, LocalizationKey.Script_2_Tower_2, context => context[CustomNpcKeys.SunsFanMudGolem]),
             tg.immediate(() => {
+                // Calculate how long you should be dead while Slacks and Sunsfan explain death
+                const deathDuration = deathConversations.map(getSoundDuration).reduce((accumulator, current) => accumulator + current + 0.5, 0)
+                setRespawnSettings(Vector(-6700, -6700, 384), deathDuration)
                 freezePlayerHero(false)
                 goalAttemptToAttackTower.start()
                 playerHero.AddNewModifier(playerHero, undefined, modifier_dk_death_chapter2_tower.name, {});
@@ -128,12 +135,18 @@ const onStart = (complete: () => void) => {
             tg.audioDialog(LocalizationKey.Script_2_Tower_4, LocalizationKey.Script_2_Tower_4, context => context[CustomNpcKeys.SunsFanMudGolem]),
             tg.audioDialog(LocalizationKey.Script_2_Tower_5, LocalizationKey.Script_2_Tower_5, context => context[CustomNpcKeys.SlacksMudGolem]),
             tg.audioDialog(LocalizationKey.Script_2_Tower_6, LocalizationKey.Script_2_Tower_6, context => context[CustomNpcKeys.SunsFanMudGolem]),
+            tg.immediate(() => {
+                if (!playerHero.IsAlive()) playerHero.RespawnHero(false, false)
+            }),
             tg.completeOnCheck(() => {
                 const modifier = playerHero.FindModifierByName(modifier_dk_death_chapter2_tower.name) as modifier_dk_death_chapter2_tower
                 if (!modifier) error("The modifier does not exists")
                 return modifier.dkRespawned
             }, 0.5),
-            tg.immediate(() => goalwaitToRespawn.complete()),
+            tg.immediate(() => {
+                goalwaitToRespawn.complete()
+                setRespawnSettings(Vector(-6130, 4860, 128), 5)
+            }),
             tg.audioDialog(LocalizationKey.Script_2_Tower_7, LocalizationKey.Script_2_Tower_7, context => context[CustomNpcKeys.SlacksMudGolem]),
             tg.immediate(() => {
                 playerHero.RemoveModifierByName(modifier_dk_death_chapter2_tower.name)

--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -19,6 +19,7 @@ let hasPlayerOrderedGlyphWhenMust = false
 let playerOrderMustCastUltimate = false
 let radiantCreepTimer: string | undefined;
 const deathConversations = [LocalizationKey.Script_2_Tower_3, LocalizationKey.Script_2_Tower_4, LocalizationKey.Script_2_Tower_5, LocalizationKey.Script_2_Tower_6]
+const deathDuration = deathConversations.map(getSoundDuration).reduce((accumulator, current) => accumulator + current + 0.5, 0)
 
 const requiredState: RequiredState = {
     heroLocation: Vector(-6130, 4860, 128),
@@ -40,7 +41,7 @@ const requiredState: RequiredState = {
         chapter2Blockades.direTopDividerCliff
     ],
     respawnLocation: Vector(-6130, 4860, 128),
-    respawnTime: 5
+    respawnTime: 5,
 }
 
 // UI Highlighting Paths
@@ -107,7 +108,6 @@ const onStart = (complete: () => void) => {
             tg.audioDialog(LocalizationKey.Script_2_Tower_2, LocalizationKey.Script_2_Tower_2, context => context[CustomNpcKeys.SunsFanMudGolem]),
             tg.immediate(() => {
                 // Calculate how long you should be dead while Slacks and Sunsfan explain death
-                const deathDuration = deathConversations.map(getSoundDuration).reduce((accumulator, current) => accumulator + current + 0.5, 0)
                 setRespawnSettings(Vector(-6700, -6700, 384), deathDuration)
                 freezePlayerHero(false)
                 goalAttemptToAttackTower.start()

--- a/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
@@ -29,7 +29,8 @@ const requiredState: RequiredState = {
         chapter2Blockades.aboveRoshanBlocker,
         chapter2Blockades.belowRoshanBlocker
     ],
-    topDireT1TowerStanding: false
+    topDireT1TowerStanding: false,
+    respawnLocation: Vector(-4941, 5874, 128),
 }
 
 let playerOrderMustBuyDemonEdge = false

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -87,5 +87,5 @@ export const defaultRequiredState: FilledRequiredState = {
 
     // Respawn positions for unintended deaths
     respawnLocation: Vector(-6700, -6700, 384),
-    respawnTime: 10
+    respawnTime: 10,
 }

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -37,6 +37,10 @@ export type RequiredState = {
 
     // Chapter 5 bounty runes
     requireBountyRunes?: boolean
+
+    // Respawn positions for unintended deaths
+    respawnLocation?: Vector
+    respawnTime?: number
 }
 
 /**
@@ -79,5 +83,9 @@ export const defaultRequiredState: FilledRequiredState = {
     blockades: [],
 
     // Chapter 5 bounty runes
-    requireBountyRunes: false
+    requireBountyRunes: false,
+
+    // Respawn positions for unintended deaths
+    respawnLocation: Vector(-6700, -6700, 384),
+    respawnTime: 10
 }

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -1,5 +1,5 @@
 import { defaultRequiredState, FilledRequiredState, RequiredState } from "./RequiredState"
-import { findAllPlayersID, freezePlayerHero, getOrError, getPlayerHero, setUnitPacifist } from "../util"
+import { findAllPlayersID, freezePlayerHero, getOrError, getPlayerHero, setRespawnSettings, setUnitPacifist } from "../util"
 import { Blockade } from "../Blockade"
 import { runeSpawnsLocations } from "../Sections/Chapter5/Shared"
 import { modifier_greevil, GreevilConfig } from "../modifiers/modifier_greevil"
@@ -20,6 +20,7 @@ export const setupState = (stateReq: RequiredState): void => {
     const hero = handleHeroCreationAndLevel(state)
     handleRequiredAbilities(state, hero)
     handleRequiredItems(state, hero)
+    handleRequiredRespawn(state)
 
     handleUnits(state)
     handleFountainTrees(state)
@@ -192,12 +193,12 @@ function handleRequiredAbilities(state: FilledRequiredState, hero: CDOTA_BaseNPC
     if (state.heroHasDoubleDamage) {
         if (!hero.HasModifier("modifier_rune_doubledamage")) {
             hero.AddNewModifier(hero, undefined, "modifier_rune_doubledamage", {
-                // Have to explicitly set duration or it assumes infinite, using standard value as of dota patch 7.28c                
+                // Have to explicitly set duration or it assumes infinite, using standard value as of dota patch 7.28c
                 duration: 45
             })
         }
     }
-    
+
     // Set remaining ability points. Print a warning if we made an obvious mistake (eg. sum of minimum levels > hero level) but allow it.
     remainingAbilityPoints = getRemainingAbilityPoints()
     if (remainingAbilityPoints < 0) {
@@ -284,6 +285,10 @@ function handleRequiredItems(state: FilledRequiredState, hero: CDOTA_BaseNPC_Her
     else if (direTop && IsValidEntity(direTop) && direTop.IsAlive()) {
         UTIL_Remove(direTop)
     }
+}
+
+function handleRequiredRespawn(state: FilledRequiredState) {
+    setRespawnSettings(state.respawnLocation, state.respawnTime)
 }
 
 function createOrMoveUnit(unitName: string, team: DotaTeam, location: Vector, faceTo?: Vector, onPostCreate?: (unit: CDOTA_BaseNPC, created: boolean) => void) {

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -470,10 +470,10 @@ export function setRespawnSettings(respawnLocation: Vector, respawnTime: number)
     }
 
     respawnListener = ListenToGameEvent("entity_killed", event => {
-        const hero = getOrError(getPlayerHero())
-        const killed = EntIndexToHScript(event.entindex_killed) as CDOTA_BaseNPC
+        const hero = getPlayerHero()
+        const killed = EntIndexToHScript(event.entindex_killed) as CDOTA_BaseNPC_Hero
 
-        if (killed.IsRealHero() && killed === hero) {
+        if (killed === hero) {
             killed.SetRespawnPosition(respawnLocation)
             killed.SetTimeUntilRespawn(respawnTime)
         }

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -458,6 +458,11 @@ export function clearAttachedHighlightParticlesFromUnits(units: CDOTA_BaseNPC[])
     }
 }
 
+/**
+ * Sets the player's respawn settings.
+ * @param respawnLocation The location the player should respawn at.
+ * @param respawnTime How long it should take the player to respawn.
+ */
 export function setRespawnSettings(respawnLocation: Vector, respawnTime: number) {
     if (respawnListener) {
         StopListeningToGameEvent(respawnListener)

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -4,6 +4,8 @@ import "./modifiers/modifier_dummy"
 import "./modifiers/modifier_particle_attach"
 import { TutorialContext } from "./TutorialGraph/Core";
 
+let respawnListener: EventListenerID | undefined
+
 /**
  * Get a list of all valid players currently in the game.
  */
@@ -335,7 +337,7 @@ export const createParticleAtLocation = (particleName: string, location: Vector)
  * @param attachPoint Optional parameter for where and how to attach the particle.
  * @returns The created particle.
  */
- export const createParticleAttachedToUnit = (particleName: string, unit: CDOTA_BaseNPC, attach: ParticleAttachment = ParticleAttachment.ABSORIGIN_FOLLOW) => {
+export const createParticleAttachedToUnit = (particleName: string, unit: CDOTA_BaseNPC, attach: ParticleAttachment = ParticleAttachment.ABSORIGIN_FOLLOW) => {
     const particleID = ParticleManager.CreateParticle(particleName, attach, unit)
     const modifier = unit.AddNewModifier(undefined, undefined, "modifier_particle_attach", {})
     if (modifier) {
@@ -454,4 +456,21 @@ export function clearAttachedHighlightParticlesFromUnits(units: CDOTA_BaseNPC[])
             }
         }
     }
+}
+
+export function setRespawnSettings(respawnLocation: Vector, respawnTime: number) {
+    if (respawnListener) {
+        StopListeningToGameEvent(respawnListener)
+        respawnListener = undefined;
+    }
+
+    respawnListener = ListenToGameEvent("entity_killed", event => {
+        const hero = getOrError(getPlayerHero())
+        const killed = EntIndexToHScript(event.entindex_killed) as CDOTA_BaseNPC
+
+        if (killed.IsRealHero() && killed === hero) {
+            killed.SetRespawnPosition(respawnLocation)
+            killed.SetTimeUntilRespawn(respawnTime)
+        }
+    }, GameRules.Addon)
 }


### PR DESCRIPTION
- Added a new utility function, `setRespawnSettings`, that sets where you respawn and how long you will be dead before respawning.
- Added a Required State for respawn location and time. Defaults to the fountain (-6700, -6700, 384) and 10 seconds when omitted.
- Tweaked Chapter 2 Tower section to manually set the timer to how long it takes Slacks/Sunsfan to tell you about being dead.
- Tweaked Chapter 2 to immediately respawn you when the conversation ends early (e.g. if you skip).
- Added Chapter 2 respawns location and duration for Required State, mostly as an example.