### PR TITLE
Add getPlayerCameraLocation

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionMovement.ts
@@ -1,6 +1,6 @@
 import * as tg from "../../TutorialGraph/index"
 import * as tut from "../../Tutorial/Core"
-import { findRealPlayerID, getOrError, getPlayerHero, setUnitPacifist } from "../../util"
+import { findRealPlayerID, getOrError, getPlayerCameraLocation, getPlayerHero, setUnitPacifist } from "../../util"
 import { RequiredState } from "../../Tutorial/RequiredState"
 import { GoalTracker } from "../../Goals"
 import { slacksFountainLocation, sunsfanFountainLocation } from "./Shared"
@@ -58,7 +58,7 @@ const onStart = (complete: () => void) => {
         tg.immediate(ctx => setUnitPacifist(ctx[CustomNpcKeys.Mirana], true)),
         tg.faceTowards(ctx => ctx[CustomNpcKeys.Mirana], playerHero.GetAbsOrigin()),
         tg.immediate(_ => goalMoveToSecondMarker.start()),
-        tg.panCameraExponential(_ => playerHero.GetAbsOrigin(), miranaSpawnLocation, 4),
+        tg.panCameraExponential(_ => getPlayerCameraLocation(), miranaSpawnLocation, 4),
         tg.setCameraTarget(ctx => ctx[CustomNpcKeys.Mirana]),
         tg.audioDialog(LocalizationKey.Script_1_Movement_6, LocalizationKey.Script_1_Movement_6, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
         tg.audioDialog(LocalizationKey.Script_1_Movement_7, LocalizationKey.Script_1_Movement_7, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),

--- a/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionShopUI.ts
@@ -1,7 +1,7 @@
 import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
-import { displayDotaErrorMessage, findRealPlayerID, getPathToItemInGuideByID, freezePlayerHero, getPlayerHero, highlightUiElement, removeHighlight } from "../../util";
+import { displayDotaErrorMessage, findRealPlayerID, getPathToItemInGuideByID, freezePlayerHero, getPlayerHero, highlightUiElement, removeHighlight, getPlayerCameraLocation } from "../../util";
 import { isShopOpen } from "../../Shop";
 import { GoalTracker } from "../../Goals";
 import { Blockade } from "../../Blockade";
@@ -128,7 +128,7 @@ const onStart = (complete: () => void) => {
                 tg.audioDialog(LocalizationKey.Script_1_Closing_5, LocalizationKey.Script_1_Closing_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
                 tg.seq([
                     tg.wait(2.5),
-                    tg.panCameraExponential(_ => playerHero.GetAbsOrigin(), bottomMidPoint, 4),
+                    tg.panCameraExponential(_ => getPlayerCameraLocation(), bottomMidPoint, 4),
                     tg.immediate(_ => blockadeRadiantBaseBottom.spawn()),
                     tg.wait(1.5),
                     tg.panCameraExponential(bottomMidPoint, middleMidPoint, 4),

--- a/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
@@ -150,7 +150,7 @@ const onStart = (complete: () => void) => {
                     }),
                     tg.setCameraTarget(context => context[CustomNpcKeys.GodzMudGolem]),
                     tg.textDialog(LocalizationKey.Script_2_Creeps_4, context => context[CustomNpcKeys.GodzMudGolem], 3),
-                    tg.panCameraLinear(context => context[CustomNpcKeys.GodzMudGolem].GetAbsOrigin(), playerHero.GetAbsOrigin(), 1),
+                    tg.panCameraLinear(context => context[CustomNpcKeys.GodzMudGolem].GetAbsOrigin(), _ => playerHero.GetAbsOrigin(), 1),
                     tg.immediate(() => freezePlayerHero(false)),
                     tg.immediate(() => {
                         goalLastHitCreeps.start()

--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -151,7 +151,7 @@ const onStart = (complete: () => void) => {
                 playerHero.SetAbsOrigin(teleportAfterRespawnLocation)
                 freezePlayerHero(false)
             }),
-            tg.panCameraExponential(_ => fountainLocation, playerHero.GetAbsOrigin(), 0.9),
+            tg.panCameraExponential(_ => fountainLocation, _ => playerHero.GetAbsOrigin(), 0.9),
             tg.goToLocation(moveAfterTeleportCloseToTowerLocation, _ => []),
             tg.immediate(() => {
                 goalGetBackToTopTowerPosition.complete()
@@ -184,7 +184,7 @@ const onStart = (complete: () => void) => {
                 ]),
                 tg.seq([
                     tg.audioDialog(LocalizationKey.Script_2_Tower_9, LocalizationKey.Script_2_Tower_9, context => context[CustomNpcKeys.SunsFanMudGolem]),
-                    tg.panCameraLinear(_ => direTopTower.GetAbsOrigin(), playerHero.GetAbsOrigin(), 1),
+                    tg.panCameraLinear(_ => direTopTower.GetAbsOrigin(), _ => playerHero.GetAbsOrigin(), 1),
                     tg.immediate(() => {
                         goalSneakThroughTower.start()
                         freezePlayerHero(false)

--- a/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
@@ -193,7 +193,7 @@ const onStart = (complete: () => void) => {
             removeHighlight(deliverItemsUIPath)
             freezePlayerHero(true)
         }),
-        tg.panCameraLinear(_ => getPlayerCameraLocation(), playerCourier.GetAbsOrigin(), 0.5),
+        tg.panCameraLinear(_ => getPlayerCameraLocation(), _ => playerCourier.GetAbsOrigin(), 0.5),
         tg.setCameraTarget(playerCourier),
         tg.completeOnCheck(() => {
             return playerHero.HasItemInInventory(daedalusName)

--- a/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
@@ -3,7 +3,7 @@ import { isShopOpen } from "../../Shop";
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { centerCameraOnHero, displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPathToItemInGuideByID, getPlayerHero, highlightUiElement, removeHighlight } from "../../util";
+import { centerCameraOnHero, displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPathToItemInGuideByID, getPlayerCameraLocation, getPlayerHero, highlightUiElement, removeHighlight } from "../../util";
 import { chapter2Blockades } from "./shared";
 import { modifier_courier_chapter_2_ms_bonus } from "../../modifiers/modifier_courier_chapter_2_ms_bonus";
 
@@ -193,7 +193,7 @@ const onStart = (complete: () => void) => {
             removeHighlight(deliverItemsUIPath)
             freezePlayerHero(true)
         }),
-        tg.panCameraLinear(playerHero.GetAbsOrigin(), playerCourier.GetAbsOrigin(), 0.5),
+        tg.panCameraLinear(_ => getPlayerCameraLocation(), playerCourier.GetAbsOrigin(), 0.5),
         tg.setCameraTarget(playerCourier),
         tg.completeOnCheck(() => {
             return playerHero.HasItemInInventory(daedalusName)

--- a/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
@@ -2,7 +2,7 @@ import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import * as shared from "./Shared"
 import { RequiredState } from "../../Tutorial/RequiredState";
-import { freezePlayerHero, getOrError, getPlayerHero, removeContextEntityIfExists } from "../../util";
+import { freezePlayerHero, getOrError, getPlayerCameraLocation, getPlayerHero, removeContextEntityIfExists } from "../../util";
 import { GoalTracker } from "../../Goals";
 
 const sectionName: SectionName = SectionName.Chapter4_Communication;
@@ -93,7 +93,7 @@ function onStart(complete: () => void) {
             tg.immediate(_ => goalChatWheelWP.start()),
             tg.waitForChatWheel(),
             tg.immediate(_ => goalChatWheelWP.complete()),
-            tg.panCameraLinear(_ => playerHero.GetAbsOrigin(), context => context[lunaName].GetAbsOrigin(), 1),
+            tg.panCameraLinear(_ => getPlayerCameraLocation(), context => context[lunaName].GetAbsOrigin(), 1),
             tg.setCameraTarget(context => context[lunaName]),
             tg.textDialog(LocalizationKey.Script_4_Communication_7, ctx => ctx[lunaName], 3),
             tg.moveUnit(context => context[lunaName], allyHeroStartLocation),

--- a/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
@@ -2,7 +2,7 @@ import * as tg from "../../TutorialGraph/index";
 import * as tut from "../../Tutorial/Core";
 import * as shared from "./Shared"
 import * as dg from "../../Dialog"
-import { displayDotaErrorMessage, findRealPlayerID, getOrError, getPlayerHero, unitIsValidAndAlive, highlightUiElement, removeHighlight, centerCameraOnHero } from "../../util";
+import { displayDotaErrorMessage, findRealPlayerID, getOrError, getPlayerHero, unitIsValidAndAlive, highlightUiElement, removeHighlight, centerCameraOnHero, getPlayerCameraLocation } from "../../util";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
 import { TutorialContext } from "../../TutorialGraph/index";
@@ -58,7 +58,7 @@ function onStart(complete: () => void) {
             tg.audioDialog(LocalizationKey.Script_4_Opening_1, LocalizationKey.Script_4_Opening_1, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             tg.audioDialog(LocalizationKey.Script_4_Opening_2, LocalizationKey.Script_4_Opening_2, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
             //Part0: The camera pans to an empty part of the map
-            tg.panCameraExponential(playerHero.GetAbsOrigin(), outpostHighgroundCenter, 0.9),
+            tg.panCameraExponential(_ => getPlayerCameraLocation(), outpostHighgroundCenter, 0.9),
             tg.audioDialog(LocalizationKey.Script_4_Opening_3, LocalizationKey.Script_4_Opening_3, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
             //Part1: Creep wave explains vision
             tg.fork(radiantCreepsNames.map(unit => tg.spawnUnit(unit, Vector(-3700, -6100, 256), DotaTeam.GOODGUYS, undefined))),

--- a/game/scripts/vscripts/Sections/Chapter4/SectionOutpost.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionOutpost.ts
@@ -2,7 +2,7 @@ import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import * as shared from "./Shared"
 import { RequiredState } from "../../Tutorial/RequiredState";
-import { getOrError, getPlayerHero, unitIsValidAndAlive, highlightUiElement, removeHighlight, freezePlayerHero, displayDotaErrorMessage, setUnitPacifist } from "../../util";
+import { getOrError, getPlayerHero, unitIsValidAndAlive, highlightUiElement, removeHighlight, freezePlayerHero, displayDotaErrorMessage, setUnitPacifist, getPlayerCameraLocation } from "../../util";
 import { GoalTracker } from "../../Goals";
 
 const sectionName: SectionName = SectionName.Chapter4_Outpost;
@@ -117,7 +117,7 @@ function onStart(complete: () => void) {
             tg.audioDialog(LocalizationKey.Script_4_Outpost_5, LocalizationKey.Script_4_Outpost_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
 
             tg.withHighlights(tg.seq([
-                tg.panCameraLinear(_ => playerHero.GetAbsOrigin(), outpostLocation, 2),
+                tg.panCameraLinear(_ => getPlayerCameraLocation(), outpostLocation, 2),
                 tg.audioDialog(LocalizationKey.Script_4_Outpost_6, LocalizationKey.Script_4_Outpost_6, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
                 tg.audioDialog(LocalizationKey.Script_4_Outpost_7, LocalizationKey.Script_4_Outpost_7, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
 

--- a/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
@@ -1,7 +1,7 @@
 import * as tg from "../../TutorialGraph/index";
 import * as tut from "../../Tutorial/Core";
 import * as shared from "./Shared"
-import { getOrError, getPlayerHero, displayDotaErrorMessage, highlightUiElement, removeHighlight, freezePlayerHero, setUnitPacifist } from "../../util";
+import { getOrError, getPlayerHero, displayDotaErrorMessage, highlightUiElement, removeHighlight, freezePlayerHero, setUnitPacifist, getPlayerCameraLocation } from "../../util";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
 
@@ -105,7 +105,7 @@ function onStart(complete: () => void) {
 
             tg.fork([
                 tg.seq([
-                    tg.panCamera(playerHero.GetAbsOrigin(), cliffLocation1, _ => cameraSpeed),
+                    tg.panCamera(_ => getPlayerCameraLocation(), cliffLocation1, _ => cameraSpeed),
                     tg.wait(1),
                     tg.panCamera(cliffLocation1, cliffLocation2, _ => cameraSpeed),
                     tg.wait(1),
@@ -113,7 +113,7 @@ function onStart(complete: () => void) {
                     tg.wait(1),
                     tg.panCamera(cliffLocation3, cliffLocation4, _ => cameraSpeed),
                     tg.wait(1),
-                    tg.panCamera(cliffLocation4, playerHero.GetAbsOrigin(), _ => cameraSpeed),
+                    tg.panCamera(cliffLocation4, _ => playerHero.GetAbsOrigin(), _ => cameraSpeed),
                 ]),
                 tg.audioDialog(LocalizationKey.Script_4_Wards_7, LocalizationKey.Script_4_Wards_7, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             ]),

--- a/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
@@ -2,7 +2,7 @@ import * as tut from "../../Tutorial/Core";
 import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
-import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerHero } from "../../util";
+import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerCameraLocation, getPlayerHero } from "../../util";
 import { chapter5Blockades, runeSpawnsLocations } from "./Shared";
 
 const sectionName: SectionName = SectionName.Chapter5_Opening;
@@ -52,8 +52,7 @@ function onStart(complete: () => void) {
                 tg.textDialog(LocalizationKey.Script_5_Opening_3, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 15),
                 // Pan camera over bounty rune spawns
                 tg.seq([
-                    tg.setCameraTarget((ctx) => ctx[CustomEntityKeys.RadiantTopBountyRune]),
-                    tg.wait(1),
+                    tg.panCameraLinear(_ => getPlayerCameraLocation(), runeSpawnsLocations.radiantTopBountyPos, 1),
                     tg.panCameraLinear(runeSpawnsLocations.radiantTopBountyPos, runeSpawnsLocations.radiantAncientsBountyPos, 2),
                     // Slightly correct panCamera targeting
                     tg.setCameraTarget((ctx) => ctx[CustomEntityKeys.RadiantAncientsBountyRune]),
@@ -83,13 +82,13 @@ function onStart(complete: () => void) {
             // Return camera to player
             tg.fork([
                 tg.textDialog(LocalizationKey.Script_5_Opening_4, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 6),
-                tg.panCameraLinear(runeSpawnsLocations.direAncientsBountyPos, playerHero.GetAbsOrigin(), 3),
+                tg.panCameraLinear(runeSpawnsLocations.direAncientsBountyPos, _ => playerHero.GetAbsOrigin(), 3),
             ]),
             tg.textDialog(LocalizationKey.Script_5_Opening_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem], 4),
             tg.textDialog(LocalizationKey.Script_5_Opening_6, ctx => ctx[CustomNpcKeys.SunsFanMudGolem], 3),
             tg.fork([
                 tg.seq([
-                    tg.panCameraLinear(playerHero.GetAbsOrigin(), runeSpawnsLocations.topPowerUpRunePos, 2),
+                    tg.panCameraLinear(_ => getPlayerCameraLocation(), runeSpawnsLocations.topPowerUpRunePos, 2),
                     tg.wait(1),
                     tg.setCameraTarget(undefined),
                     tg.immediate(_ => centerCameraOnHero()),

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -3,7 +3,7 @@ import * as tg from "../../TutorialGraph/index";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
 import { chapter5Blockades, runeSpawnsLocations } from "./Shared";
-import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerHero, setUnitPacifist, unitIsValidAndAlive } from "../../util";
+import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerCameraLocation, getPlayerHero, setUnitPacifist, unitIsValidAndAlive } from "../../util";
 import { modifier_custom_roshan_attack_speed } from "../../modifiers/modifier_custom_roshan_attack_speed";
 
 const sectionName: SectionName = SectionName.Chapter5_Roshan;
@@ -101,7 +101,7 @@ function onStart(complete: () => void) {
                     tg.goToLocation(roshPitGoalPosition),
                 ]),
                 tg.seq([
-                    tg.panCameraLinear(playerHero.GetOrigin(), roshPitGoalPosition, 2),
+                    tg.panCameraLinear(_ => getPlayerCameraLocation(), roshPitGoalPosition, 2),
                     tg.wait(2),
                     tg.immediate(() => canPlayerIssueOrders = true),
                     tg.setCameraTarget(undefined),

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -455,3 +455,23 @@ export function clearAttachedHighlightParticlesFromUnits(units: CDOTA_BaseNPC[])
         }
     }
 }
+
+/**
+ * Returns the current camera location (technically the target, not the origin) of the player.
+ * @returns Current camera location of the player.
+ */
+export function getPlayerCameraLocation() {
+    const playerHero = getOrError(getPlayerHero(), "Could not get player hero");
+    const owner = playerHero.GetOwner();
+    if (!owner || !IsValidEntity(owner)) {
+        error("Could not get player hero owner");
+    }
+
+    const cameraOrigin = owner.GetAbsOrigin();
+    const cameraForward = owner.GetAngles().Forward();
+
+    // Assume fixed camera distance stored in dota_camera_distance
+    const cameraDistance = cvar_getf("dota_camera_distance");
+
+    return GetGroundPosition(cameraOrigin.__add(cameraForward.__mul(cameraDistance)), undefined);
+}


### PR DESCRIPTION
- Gets the camera's look at location (`origin + foward * cameraDistance`)
- Useful for camera panning as starting point, when previously we snapped to the hero's position
- Also corrected places that weren't passing functions when getting the hero location for panning