### PR TITLE
Put dialog more towards bottom

### DIFF
--- a/content/panorama/styles/custom_game/dialog.css
+++ b/content/panorama/styles/custom_game/dialog.css
@@ -156,7 +156,7 @@
 #DialogPanel {
     horizontal-align: center;
     vertical-align: bottom;
-    margin-bottom: 300px;
+    margin-bottom: 130px;
     min-width: 500px;
     min-height: 180px;
     transition-property: pre-transform-scale2d, transform, opacity;


### PR DESCRIPTION
Was more towards the center before where it often overlapped with gameplay

![image](https://user-images.githubusercontent.com/2614101/111034787-1fee0300-840f-11eb-878d-d8565d99c4ce.png)
![image](https://user-images.githubusercontent.com/2614101/111034792-23818a00-840f-11eb-8996-68ce4d966af8.png)
![image](https://user-images.githubusercontent.com/2614101/111034795-2bd9c500-840f-11eb-9b0c-8ab943565273.png)
