### PR TITLE
Dire creeps now only spawn in SectionCreeps, preventing an exploit

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
@@ -65,12 +65,10 @@ const onStart = (complete: () => void) => {
     const goalKillSniper = goalTracker.addBoolean("Kill Sniper.");
 
     if (!radiantCreeps) {
-        radiantCreeps = createLaneCreeps(radiantCreepsNames, radiantCreepsSpawnLocation, DotaTeam.GOODGUYS, false);
+        radiantCreeps = createLaneCreeps(radiantCreepsNames, radiantCreepsSpawnLocation, DotaTeam.GOODGUYS, true);
     }
 
-    if (!direCreeps) {
-        direCreeps = createLaneCreeps(direCreepNames, direCreepsSpawnLocation, DotaTeam.BADGUYS, false);
-    }
+    direCreeps = createLaneCreeps(direCreepNames, direCreepsSpawnLocation, DotaTeam.BADGUYS, true);
 
     graph = tg.withGoals(context => goalTracker.getGoals(),
         tg.seq([
@@ -80,12 +78,6 @@ const onStart = (complete: () => void) => {
                 if (radiantCreeps) {
                     for (const radiantCreep of radiantCreeps) {
                         SendCreepToFight(radiantCreep);
-                    }
-                }
-
-                if (direCreeps) {
-                    for (const direCreep of direCreeps) {
-                        SendCreepToFight(direCreep)
                     }
                 }
             }),

--- a/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
@@ -3,7 +3,7 @@ import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
 import { findRealPlayerID, freezePlayerHero, getPlayerHero, removeContextEntityIfExists } from "../../util";
-import { chapter2Blockades, Chapter2SpecificKeys, direCreepNames, radiantCreepsNames } from "./shared";
+import { chapter2Blockades, Chapter2SpecificKeys, radiantCreepsNames } from "./shared";
 
 const sectionName: SectionName = SectionName.Chapter2_Opening
 let graph: tg.TutorialStep | undefined = undefined
@@ -11,7 +11,6 @@ let graph: tg.TutorialStep | undefined = undefined
 const inFrontOfBarracksLocation = Vector(-6589, -4468, 259)
 const moveNextToBarracksLocation = Vector(-6574, -3742, 256)
 const radiantCreepsSpawnLocation = Vector(-6795, -3474, 256)
-const direCreepsSpawnLocation = Vector(-5911, 5187, 128)
 const radiantCreepsMoveToPrepareLaunchAssaultLocation = Vector(-6600, -2425, 128)
 const moveToPrepareToLaunchAssaultLocation = Vector(-6600, -2745, 128)
 const radiantCreepsPrepareToAttackLocation = Vector(-6288, 3280, 128)
@@ -117,7 +116,6 @@ const onStart = (complete: () => void) => {
             tg.audioDialog(LocalizationKey.Script_2_Opening_13, LocalizationKey.Script_2_Opening_13, context => context[CustomNpcKeys.SlacksMudGolem]),
 
             tg.fork(_ => radiantCreepsNames.map(unit => tg.spawnUnit(unit, radiantCreepsSpawnLocation, DotaTeam.GOODGUYS, undefined, true))),
-            tg.fork(_ => direCreepNames.map(unit => tg.spawnUnit(unit, direCreepsSpawnLocation, DotaTeam.BADGUYS, undefined, true))),
             tg.immediate(context => {
                 // Group radiant creeps
                 const creeps = Entities.FindAllByClassname("npc_dota_creature") as CDOTA_BaseNPC[];

--- a/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
+++ b/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
@@ -8,6 +8,7 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
     IsHidden() { return true }
     IsPurgable() { return false }
     IsDebuff() { return false }
+    RemoveOnDeath() { return false }
 
     currentStage: LastHitStages = LastHitStages.LAST_HIT
     private successLocalizationKeys: LocalizationKey[] = [LocalizationKey.Script_2_Creeps_5, LocalizationKey.Script_2_Creeps_6, LocalizationKey.Script_2_Creeps_7]


### PR DESCRIPTION
- Dire Creeps no longer spawn in the SectionOpening; instead, they spawn at the beginning of SectionCreeps.
- Slight changes to the logic to accommodate the change.

Fixes https://github.com/ModDota/dota-tutorial/issues/260