### PR TITLE
Adjusted DK modifier in Section Creeps

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
@@ -4,7 +4,7 @@ import { modifier_sniper_deny_chapter2_creeps } from "../../modifiers/modifier_s
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { clearAttachedHighlightParticlesFromUnits, findRealPlayerID, freezePlayerHero, getPlayerHero, highlight, removeContextEntityIfExists, setUnitPacifist } from "../../util";
+import { clearAttachedHighlightParticlesFromUnits, findRealPlayerID, freezePlayerHero, getOrError, getPlayerHero, highlight, removeContextEntityIfExists, setUnitPacifist } from "../../util";
 import { Chapter2SpecificKeys, LastHitStages, radiantCreepsNames, direCreepNames, chapter2Blockades } from "./shared";
 
 const sectionName: SectionName = SectionName.Chapter2_Creeps
@@ -152,13 +152,15 @@ const onStart = (complete: () => void) => {
                                 units: direCreeps
                             })
                         }
-                        const modifier = playerHero.AddNewModifier(playerHero, undefined, modifier_dk_last_hit_chapter2_creeps.name, {}) as modifier_dk_last_hit_chapter2_creeps
+                        const modifier = playerHero.AddNewModifier(playerHero, undefined, modifier_dk_last_hit_chapter2_creeps.name, { lastHits: lastHitCount, lastHitBreatheFire: lastHitBreathFireCount, denies: denyCount }) as modifier_dk_last_hit_chapter2_creeps
                         if (modifier) modifier.setCurrentState(LastHitStages.LAST_HIT);
                     }),
                     tg.completeOnCheck(_ => {
-                        const currentLastHits = playerHero.GetModifierStackCount(modifier_dk_last_hit_chapter2_creeps.name, playerHero);
+                        const lastHitModifier = getOrError(playerHero.FindModifierByName(modifier_dk_last_hit_chapter2_creeps.name)) as modifier_dk_last_hit_chapter2_creeps
+                        const currentLastHits = lastHitModifier.GetStackCount()
+                        const lastDialogEnded = lastHitModifier.dialogFinishedPlaying
                         goalLastHitCreeps.setValue(currentLastHits)
-                        return currentLastHits >= lastHitCount;
+                        return currentLastHits >= lastHitCount && lastDialogEnded;
                     }, 0.1),
                     tg.immediate(() => {
                         goalLastHitCreeps.complete()
@@ -169,7 +171,7 @@ const onStart = (complete: () => void) => {
                             if (modifier) modifier.setCurrentState(LastHitStages.LAST_HIT_BREATHE_FIRE)
                             else {
                                 // Technically, this section of code should never happen. But you never know. Programming is black magic sometimes.
-                                const modifier = playerHero.AddNewModifier(playerHero, undefined, modifier_dk_last_hit_chapter2_creeps.name, {}) as modifier_dk_last_hit_chapter2_creeps
+                                const modifier = playerHero.AddNewModifier(playerHero, undefined, modifier_dk_last_hit_chapter2_creeps.name, { lastHits: lastHitCount, lastHitBreatheFire: lastHitBreathFireCount, denies: denyCount }) as modifier_dk_last_hit_chapter2_creeps
                                 if (modifier) modifier.setCurrentState(LastHitStages.LAST_HIT_BREATHE_FIRE)
                             }
                         }
@@ -237,7 +239,7 @@ const onStart = (complete: () => void) => {
                             if (modifier) modifier.setCurrentState(LastHitStages.LAST_HIT_DENY)
                             else {
                                 // Technically, this section of code should never happen. But you never know. Programming is black magic sometimes.
-                                const modifier = playerHero.AddNewModifier(playerHero, undefined, modifier_dk_last_hit_chapter2_creeps.name, {}) as modifier_dk_last_hit_chapter2_creeps
+                                const modifier = playerHero.AddNewModifier(playerHero, undefined, modifier_dk_last_hit_chapter2_creeps.name, { lastHits: lastHitCount, lastHitBreatheFire: lastHitBreathFireCount, denies: denyCount }) as modifier_dk_last_hit_chapter2_creeps
                                 if (modifier) modifier.setCurrentState(LastHitStages.LAST_HIT_DENY)
                             }
                         }

--- a/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
+++ b/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
@@ -13,10 +13,21 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
     currentStage: LastHitStages = LastHitStages.LAST_HIT
     private successLocalizationKeys: LocalizationKey[] = [LocalizationKey.Script_2_Creeps_5, LocalizationKey.Script_2_Creeps_6, LocalizationKey.Script_2_Creeps_7]
     private missLocalizationKeys: LocalizationKey[] = [LocalizationKey.Script_2_Creeps_8, LocalizationKey.Script_2_Creeps_9, LocalizationKey.Script_2_Creeps_10]
+    dialogFinishedPlaying: boolean = false
 
-    OnCreated() {
+    lastHits?: number
+    lastHitBreatheFire?: number
+    denies?: number
+
+    OnCreated(keys: { lastHits: number, lastHitBreatheFire: number, denies: number }) {
         if (!IsServer()) return;
         this.SetStackCount(0);
+
+        if (keys) {
+            this.lastHits = keys.lastHits
+            this.lastHitBreatheFire = keys.lastHitBreatheFire
+            this.denies = keys.denies
+        }
     }
 
     OnRefresh() {
@@ -58,6 +69,9 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
     }
 
     LastHit(event: ModifierAttackEvent) {
+        // Ignore if we already reached the maximum
+        if (this.lastHits && this.GetStackCount() === this.lastHits) return;
+
         if (event.attacker != this.GetParent()) {
             // Check if killer is on DK's team
             if (event.attacker.GetTeamNumber() == this.GetParent().GetTeamNumber()) {
@@ -82,12 +96,24 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
 
         // Play "nice hit!" sound from Godz - currently text, later will change to audio when we'll have actual sounds
         const chosenLocalizationKey = this.successLocalizationKeys[RandomInt(0, this.successLocalizationKeys.length - 1)]
-        dg.playText(chosenLocalizationKey, GameRules.Addon.context[CustomNpcKeys.GodzMudGolem], 3)
+
+        // Only the last dialog tags dialogFinishedPlaying
+        if (this.lastHits && this.lastHits - 1 === this.GetStackCount()) {
+            dg.playText(chosenLocalizationKey, GameRules.Addon.context[CustomNpcKeys.GodzMudGolem], 3, () => {
+                this.dialogFinishedPlaying = true
+            })
+        }
+        else {
+            dg.playText(chosenLocalizationKey, GameRules.Addon.context[CustomNpcKeys.GodzMudGolem], 3)
+        }
 
         this.IncrementStackCount();
     }
 
     LastHitBreathFire(event: ModifierAttackEvent) {
+        // Ignore if we already reached the maximum
+        if (this.lastHitBreatheFire && this.lastHitBreatheFire === this.GetStackCount()) return;
+
         if (event.attacker != this.GetParent()) return;
         if (event.inflictor != this.GetParent().FindAbilityByName("dragon_knight_breathe_fire")) return
 
@@ -100,6 +126,9 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
     }
 
     LastHitDeny(event: ModifierAttackEvent) {
+        // Ignore if we already reached the maximum
+        if (this.denies && this.denies === this.GetStackCount()) return
+
         if (event.attacker != this.GetParent()) return;
 
         if (event.unit) {


### PR DESCRIPTION
Fixes https://github.com/ModDota/dota-tutorial/issues/247

Changes to the modifier:
- The modifier now knows how many stacks it needs to reach, and will no longer accumulate before the state changes (e.g. when last hitting multiple units with Breathe Fire).
- The graph was changed to have Breathe Fire dialog wait for the last hit dialog to complete before playing.