### PR TITLE
Polished Section 2 Creeps

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
+++ b/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
@@ -38,11 +38,9 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
 
         if (this.currentStage === LastHitStages.LAST_HIT && event.target.GetTeamNumber() === this.GetParent().GetTeamNumber()) {
             return
-        }
-        else if (this.currentStage === LastHitStages.LAST_HIT_BREATHE_FIRE) {
+        } else if (this.currentStage === LastHitStages.LAST_HIT_BREATHE_FIRE) {
             return
-        }
-        else if (this.currentStage === LastHitStages.LAST_HIT_DENY && event.target.GetTeamNumber() !== this.GetParent().GetTeamNumber()) {
+        } else if (this.currentStage === LastHitStages.LAST_HIT_DENY && event.target.GetTeamNumber() !== this.GetParent().GetTeamNumber()) {
             return
         }
 

--- a/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
+++ b/game/scripts/vscripts/modifiers/modifier_dk_last_hit_chapter2_creeps.ts
@@ -26,7 +26,35 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
 
     DeclareFunctions(): ModifierFunction[] {
         return [ModifierFunction.ON_DEATH,
-        ModifierFunction.MANA_REGEN_CONSTANT]
+        ModifierFunction.MANA_REGEN_CONSTANT,
+        ModifierFunction.ON_ATTACK_LANDED,
+        ModifierFunction.PREATTACK_BONUS_DAMAGE]
+    }
+
+    OnAttackLanded(event: ModifierAttackEvent): void {
+        if (!IsServer()) return;
+        if (event.attacker != this.GetParent()) return;
+        if (!isCustomLaneCreepUnit(event.target)) return
+
+        if (this.currentStage === LastHitStages.LAST_HIT && event.target.GetTeamNumber() === this.GetParent().GetTeamNumber()) {
+            return
+        }
+        else if (this.currentStage === LastHitStages.LAST_HIT_BREATHE_FIRE) {
+            return
+        }
+        else if (this.currentStage === LastHitStages.LAST_HIT_DENY && event.target.GetTeamNumber() !== this.GetParent().GetTeamNumber()) {
+            return
+        }
+
+        Timers.CreateTimer(FrameTime(), () => {
+            if (event.target.IsAlive() && event.target.GetHealthPercent() < 8) {
+                SendOverheadEventMessage(undefined, OverheadAlert.LAST_HIT_EARLY, event.target, 500, undefined)
+            }
+        })
+    }
+
+    GetModifierPreAttack_BonusDamage(): number {
+        return 25;
     }
 
     GetModifierConstantManaRegen(): number {
@@ -68,6 +96,8 @@ export class modifier_dk_last_hit_chapter2_creeps extends BaseModifier {
                         // Play "you missed!" sound from Godz - currently text, later will change to audio when we'll have actual sounds
                         const chosenLocalizaionKey = this.missLocalizationKeys[RandomInt(0, this.missLocalizationKeys.length - 1)];
                         dg.playText(chosenLocalizaionKey, GameRules.Addon.context[CustomNpcKeys.GodzMudGolem], 3)
+
+                        SendOverheadEventMessage(undefined, OverheadAlert.LAST_HIT_MISS, event.unit, 0, undefined)
                     }
                 }
             }

--- a/game/scripts/vscripts/modifiers/modifier_sniper_deny_chapter2_creeps.ts
+++ b/game/scripts/vscripts/modifiers/modifier_sniper_deny_chapter2_creeps.ts
@@ -1,5 +1,5 @@
 import { BaseModifier, registerModifier } from "../lib/dota_ts_adapter";
-import { CalculateDirectionToPosition, CalculateDistance2D, getPlayerHero, isCustomLaneCreepUnit } from "../util";
+import { DirectionToPosition, Distance2D, getPlayerHero, isCustomLaneCreepUnit } from "../util";
 
 @registerModifier()
 export class modifier_sniper_deny_chapter2_creeps extends BaseModifier {
@@ -37,15 +37,14 @@ export class modifier_sniper_deny_chapter2_creeps extends BaseModifier {
             if (denyableCreeps.length > 0) {
                 const closestCreep = denyableCreeps[0];
 
-                const distance = CalculateDistance2D(closestCreep.GetAbsOrigin(), this.GetParent().GetAbsOrigin())
-                if (distance > this.GetParent().Script_GetAttackRange())
-                    ExecuteOrderFromTable(
-                        {
-                            OrderType: UnitOrder.MOVE_TO_TARGET,
-                            UnitIndex: this.GetParent().entindex(),
-                            TargetIndex: closestCreep.entindex(),
-                        })
-                else {
+                const distance = Distance2D(closestCreep.GetAbsOrigin(), this.GetParent().GetAbsOrigin())
+                if (distance > this.GetParent().Script_GetAttackRange()) {
+                    ExecuteOrderFromTable({
+                        OrderType: UnitOrder.MOVE_TO_TARGET,
+                        UnitIndex: this.GetParent().entindex(),
+                        TargetIndex: closestCreep.entindex(),
+                    })
+                } else {
                     ExecuteOrderFromTable({
                         OrderType: UnitOrder.ATTACK_TARGET,
                         UnitIndex: this.GetParent().entindex(),
@@ -58,29 +57,25 @@ export class modifier_sniper_deny_chapter2_creeps extends BaseModifier {
                     const closestCreep = alliedCreeps[0]
 
                     // Calculate the position Sniper should move behind enemy lines
-                    const direction = CalculateDirectionToPosition(closestCreep.GetAbsOrigin(), this.anchorPoint)
+                    const direction = DirectionToPosition(closestCreep.GetAbsOrigin(), this.anchorPoint)
                     const position = (closestCreep.GetAbsOrigin() + direction * 300) as Vector
 
-                    if (CalculateDistance2D(this.GetParent().GetAbsOrigin(), position) > 100) {
-                        ExecuteOrderFromTable(
-                            {
-                                OrderType: UnitOrder.MOVE_TO_POSITION,
-                                UnitIndex: this.GetParent().entindex(),
-                                Position: position
-                            }
-                        )
+                    if (Distance2D(this.GetParent().GetAbsOrigin(), position) > 100) {
+                        ExecuteOrderFromTable({
+                            OrderType: UnitOrder.MOVE_TO_POSITION,
+                            UnitIndex: this.GetParent().entindex(),
+                            Position: position
+                        })
                     }
-                }
-                else {
+                } else {
 
-                    if (CalculateDistance2D(this.GetParent().GetAbsOrigin(), this.anchorPoint) > 100) {
+                    if (Distance2D(this.GetParent().GetAbsOrigin(), this.anchorPoint) > 100) {
                         ExecuteOrderFromTable({
                             OrderType: UnitOrder.MOVE_TO_POSITION,
                             UnitIndex: this.GetParent().entindex(),
                             Position: this.anchorPoint
                         })
-                    }
-                    else {
+                    } else {
                         const playerHero = getPlayerHero()
                         if (playerHero) {
                             this.GetParent().FaceTowards(playerHero.GetAbsOrigin())
@@ -88,8 +83,7 @@ export class modifier_sniper_deny_chapter2_creeps extends BaseModifier {
                     }
                 }
             }
-        }
-        else {
+        } else {
             const attackTarget = this.GetParent().GetAttackTarget()
             const playerHero = getPlayerHero();
             if (playerHero && attackTarget != playerHero) {

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -513,7 +513,7 @@ export function setRespawnSettings(respawnLocation: Vector, respawnTime: number)
  * Calculates the distance in 2D between two points.
  * @returns The distance between the two points.
  */
-export function CalculateDistance2D(point1: Vector, point2: Vector): number {
+export function Distance2D(point1: Vector, point2: Vector): number {
     return ((point1 - point2) as Vector).Length2D()
 }
 
@@ -523,6 +523,6 @@ export function CalculateDistance2D(point1: Vector, point2: Vector): number {
  * @param towards_pos The position where the vector should point.
  * @returns The normalized vector pointing towards the second vector argument.
  */
-export function CalculateDirectionToPosition(origin_pos: Vector, towards_pos: Vector): Vector {
+export function DirectionToPosition(origin_pos: Vector, towards_pos: Vector): Vector {
     return ((towards_pos - origin_pos) as Vector).Normalized();
 }

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -507,3 +507,22 @@ export function setRespawnSettings(respawnLocation: Vector, respawnTime: number)
         }
     }, GameRules.Addon)
 }
+
+
+/**
+ * Calculates the distance in 2D between two points.
+ * @returns The distance between the two points.
+ */
+export function CalculateDistance2D(point1: Vector, point2: Vector): number {
+    return ((point1 - point2) as Vector).Length2D()
+}
+
+/**
+ * Calculates the direction from the first position to the second.
+ * @param origin_pos The position where the vector should originate from.
+ * @param towards_pos The position where the vector should point.
+ * @returns The normalized vector pointing towards the second vector argument.
+ */
+export function CalculateDirectionToPosition(origin_pos: Vector, towards_pos: Vector): Vector {
+    return ((towards_pos - origin_pos) as Vector).Normalized();
+}


### PR DESCRIPTION
- Sniper's bot will now keep himself behind enemy lines to make it more realistic. If all of his allies fall, he will fall back to an anchor point, and will regroup with his new allies, staying behind them.
- Sniper now has +100 damage (down from +600) to make not instantly explode any creep he denies. However, to make him more consistent with denies, he also now has +50 attack speed. Those values are removed when Sniper fights you in the last phase of the section.
- When the player hits an appropriate creep (enemies in last hit stage, allies in deny stage, none in breathe fire stage), and the creep stays alive with less than 7% of its health, a small "early!" message will show up above the creep, to hint that the player was attacking too early.
- When the player "misses" a last hit (<300 distance from enemy that died not thanks to the player), a small "miss" message will show up above the creep.
- Added two new util functions for calculation distance and direction. Nothing special, I just don't want to repeat myself anymore.
- Other slight fixes to behavior and general polish.

Fixes https://github.com/ModDota/dota-tutorial/issues/267