### PR TITLE
Use original video aspect ratio

### DIFF
--- a/content/panorama/styles/custom_game/videos.css
+++ b/content/panorama/styles/custom_game/videos.css
@@ -20,7 +20,7 @@
 
 .MovieContainerMuting {
     width: 1050px;
-    height: 670px;
+    height: 703px;
     align: center center;
     background-color: #111920ff;
     border-radius: 5px;
@@ -37,7 +37,7 @@
 
 .CustomMoviePanelMuting {
     width: 1000px;
-    height: 550px;
+    height: 583px;
     align: center center;
     background-size: 100% 100%;
     box-shadow: #000000aa -4px -4px 8px 8px;
@@ -104,7 +104,7 @@
 
 .MovieContainerGuides {
     width: 1150px;
-    height: 770px;
+    height: 972px;
     align: center center;
     background-color: #111920ff;
     border-radius: 5px;
@@ -113,7 +113,7 @@
 
 .CustomMoviePanelGuides {
     width: 1100px;
-    height: 650px;
+    height: 852px;
     align: center center;
     background-size: 100% 100%;
     box-shadow: #000000aa -4px -4px 8px 8px;


### PR DESCRIPTION
Guides res: 1860x1440
Muting res: 1200x700

Might want to downscale them  ourselves so Dota doesn't do ugly rescaling of its own.

Fixes #238 

![image](https://user-images.githubusercontent.com/2614101/111085538-ae49ae00-850f-11eb-9d72-9daf466ee33a.png)
![image](https://user-images.githubusercontent.com/2614101/111085566-c4576e80-850f-11eb-9c54-5784e866b831.png)
