### PR TITLE
Add dialog token

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -14,6 +14,15 @@ interface DialogReceivedEvent {
     DialogText: string;
     DialogEntIndex: EntityIndex;
     DialogAdvanceTime: number;
+    Token: DialogToken;
+}
+
+interface DialogClearEvent {
+    Token?: DialogToken;
+}
+
+interface DialogCompleteEvent {
+    Token: DialogToken;
 }
 
 interface DetectCommandEvent {
@@ -61,9 +70,9 @@ interface PlayVideoEvent {
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
-    dialog_complete: {};
+    dialog_complete: DialogCompleteEvent;
     dialog: DialogReceivedEvent;
-    dialog_clear: {};
+    dialog_clear: DialogClearEvent;
     ui_loaded: {};
     detect_camera_movement: {};
     camera_movement_detected: {};

--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -93,3 +93,5 @@ declare const enum ParticleName {
 }
 
 type VideoName = "guides" | "muting"
+
+type DialogToken = number

--- a/content/panorama/scripts/custom_game/dialog.ts
+++ b/content/panorama/scripts/custom_game/dialog.ts
@@ -98,6 +98,9 @@ function HideDialog(event: DialogClearEvent) {
 
 function OnCloseDialogButtonPressed() {
     pendingDialog = undefined;
+
+    // Store current token in case SendCustomGameEventToServer directly calls the
+    // server function which could start a new dialog rather than sending a network message.
     const token = currentToken;
     currentToken = undefined;
     $("#DialogPanel").SetHasClass("Visible", false);

--- a/content/panorama/scripts/custom_game/dialog.ts
+++ b/content/panorama/scripts/custom_game/dialog.ts
@@ -64,7 +64,9 @@ function AdvanceDialogThink() {
         dialogPanel.SetHasClass("Visible", false);
         const token = currentToken;
         currentToken = undefined;
-        GameEvents.SendCustomGameEventToServer("dialog_complete", { Token: token });
+        if (token) {
+            GameEvents.SendCustomGameEventToServer("dialog_complete", { Token: token });
+        }
         return;
     }
 
@@ -99,7 +101,9 @@ function OnCloseDialogButtonPressed() {
     const token = currentToken;
     currentToken = undefined;
     $("#DialogPanel").SetHasClass("Visible", false);
-    GameEvents.SendCustomGameEventToServer("dialog_complete", { Token: token });
+    if (token) {
+        GameEvents.SendCustomGameEventToServer("dialog_complete", { Token: token });
+    }
 }
 
 GameEvents.Subscribe("dialog", OnDialogReceived);

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -695,14 +695,24 @@ export const withGoals = (goals: tg.StepArgument<Goal[]>, step: tg.TutorialStep)
 export const audioDialog = (soundName: tg.StepArgument<string>, text: tg.StepArgument<string>, unit: tg.StepArgument<CDOTA_BaseNPC>, extraDelaySeconds?: tg.StepArgument<number>) => {
     const defaultExtraDelaySeconds = 0.5
 
+    let dialogToken: DialogToken | undefined
+
     return tg.step((context, complete) => {
         const actualSoundName = tg.getArg(soundName, context)
         const actualUnit = tg.getArg(unit, context)
         const actualText = tg.getArg(text, context)
         const actualExtraDelaySeconds = tg.getOptionalArg(extraDelaySeconds, context)
 
-        dg.playAudio(actualSoundName, actualText, actualUnit, actualExtraDelaySeconds === undefined ? defaultExtraDelaySeconds : actualExtraDelaySeconds, complete)
-    }, _ => dg.stop())
+        dialogToken = dg.playAudio(actualSoundName, actualText, actualUnit, actualExtraDelaySeconds === undefined ? defaultExtraDelaySeconds : actualExtraDelaySeconds, () => {
+            dialogToken = undefined
+            complete()
+        })
+    }, _ => {
+        if (dialogToken !== undefined) {
+            dg.stop(dialogToken)
+            dialogToken = undefined
+        }
+    })
 }
 
 /**
@@ -712,13 +722,23 @@ export const audioDialog = (soundName: tg.StepArgument<string>, text: tg.StepArg
  * @param waitSeconds Time to wait for in seconds.
  */
 export const textDialog = (text: tg.StepArgument<string>, unit: tg.StepArgument<CDOTA_BaseNPC>, waitSeconds: tg.StepArgument<number>) => {
+    let dialogToken: DialogToken | undefined
+
     return tg.step((context, complete) => {
         const actualText = tg.getArg(text, context)
         const actualUnit = tg.getArg(unit, context)
         const actualWaitSeconds = tg.getArg(waitSeconds, context)
 
-        dg.playText(actualText, actualUnit, actualWaitSeconds, complete)
-    }, _ => dg.stop())
+        dialogToken = dg.playText(actualText, actualUnit, actualWaitSeconds, () => {
+            dialogToken = undefined
+            complete()
+        })
+    }, _ => {
+        if (dialogToken !== undefined) {
+            dg.stop(dialogToken)
+            dialogToken = undefined
+        }
+    })
 }
 
 /**


### PR DESCRIPTION
Fixes #284 

- Playing a dialog generates a token which can be used to stop that exact dialog
- Previously if there were two dialogs in a fork, and that fork got cancelled, we called stop dialog twice, and it would skip the next dialog if there was one immediately afterwards (although the audio was still playing and overlapping)
- Now the steps only cancel their own dialog using their token and we are fine