### PR TITLE
Highlight and CH2 sectionCourier fixes

### DIFF
--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -99,8 +99,7 @@ function highlightUiElement(event: NetworkedData<HighlightElementEvent>) {
         highlightPanel.hittest = false; // Dont block interactions
         highlightPanel.AddClass("UIHighlightScalingAnimation")
         $.Schedule(0.5, () => {
-            if (highlightPanel.IsValid())
-            {
+            if (highlightPanel.IsValid()) {
                 highlightPanel.RemoveClass("UIHighlightScalingAnimation")
                 highlightPanel.AddClass("UIHighlight");
             }

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -99,8 +99,11 @@ function highlightUiElement(event: NetworkedData<HighlightElementEvent>) {
         highlightPanel.hittest = false; // Dont block interactions
         highlightPanel.AddClass("UIHighlightScalingAnimation")
         $.Schedule(0.5, () => {
-            highlightPanel.RemoveClass("UIHighlightScalingAnimation")
-            highlightPanel.AddClass("UIHighlight");
+            if (highlightPanel.IsValid())
+            {
+                highlightPanel.RemoveClass("UIHighlightScalingAnimation")
+                highlightPanel.AddClass("UIHighlight");
+            }
         })
 
         highlightPanel.SetParent(hudRoot);

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -97,7 +97,12 @@ function highlightUiElement(event: NetworkedData<HighlightElementEvent>) {
 
         const highlightPanel = $.CreatePanel("Panel", $.GetContextPanel(), "UIHighlight");
         highlightPanel.hittest = false; // Dont block interactions
-        highlightPanel.AddClass("UIHighlight");
+        highlightPanel.AddClass("UIHighlightScalingAnimation")
+        $.Schedule(0.5, () => {
+            highlightPanel.RemoveClass("UIHighlightScalingAnimation")
+            highlightPanel.AddClass("UIHighlight");
+        })
+
         highlightPanel.SetParent(hudRoot);
 
         // Set size/position
@@ -111,10 +116,16 @@ function highlightUiElement(event: NetworkedData<HighlightElementEvent>) {
             $.Schedule(duration, () => removeHighlight({ path }));
         }
 
+        // Shop guide items
         const isShopGuideItem = path.includes("HUDElements/shop/GuideFlyout/ItemsArea/ItemBuildContainer")
         if (isShopGuideItem) {
             const needsAdjusting = !Game.IsShopOpen()
             checkShopHighlightItemPanel(highlightPanel, element, needsAdjusting)
+        }
+
+        // Deliver Courier path
+        if (path === "HUDElements/lower_hud/shop_launcher_block/quickbuy/ShopCourierControls/CourierControls/DeliverItemsButton") {
+            highlightPanel.AddClass("UIHighlightCourierDeliverButton")
         }
     }
 }

--- a/content/panorama/styles/custom_game/hud.css
+++ b/content/panorama/styles/custom_game/hud.css
@@ -3,15 +3,47 @@
     height: 100%;
 }
 
+.UIHighlightScalingAnimation
+{
+    animation-name: scalingAnimationUI;
+    animation-duration: 0.5s;
+    animation-iteration-count: 1;
+    animation-timing-function: linear;
+}
+
+@keyframes 'scalingAnimationUI' {
+    0% {
+        box-shadow: 0 0 5px gold;
+        transform: translate3d( 25px, -620px, -0px );
+        pre-transform-scale2d: 5, 5;
+    }
+    25% {
+        box-shadow: 0 0 10px gold;
+        pre-transform-scale2d: 4, 4;
+    }
+    50% {
+        box-shadow: 0 0 20px gold;
+        pre-transform-scale2d: 3, 3;
+    }
+    75% {
+        box-shadow: 0 0 10px gold;
+        pre-transform-scale2d: 2, 2;
+    }
+    100% {
+        box-shadow: 0 0 5px gold;
+        pre-transform-scale2d: 1, 1;
+    }
+}
+
 .UIHighlight {
     z-index: 100;
-    animation-name: glow;
+    animation-name: highlightGlow;
     animation-duration: 1s;
     animation-iteration-count: infinite;
     animation-timing-function: linear;
 }
 
-@keyframes 'glow' {
+@keyframes 'highlightGlow' {
     0% {
         box-shadow: 0 0 5px gold;
     }
@@ -19,7 +51,7 @@
         box-shadow: 0 0 10px gold;
     }
     50% {
-        box-shadow: 0 0 20px gold;
+        box-shadow: 0 0 30px gold;
     }
     75% {
         box-shadow: 0 0 10px gold;
@@ -27,6 +59,13 @@
     100% {
         box-shadow: 0 0 5px gold;
     }
+}
+
+.UIHighlightCourierDeliverButton
+{
+    border: 8px solid    #CFB53B;
+    border-radius: 50%;
+    margin-left: -5px;
 }
 
 #ChaptersMenu {


### PR DESCRIPTION
- Added a highlight animation for all highlights (didn't test ALL of them, but the ones I tested seem good). It will now fly from above the element with 5x the size, and will centralize itself in its actual position over 0.5 seconds.
- Added a hardcoded path and class for the Deliver Items button, which is a circle. We can do the same for Scan and Glyph, but it might not be necessary because it looked good either way.
- Fixed the Dire Secret Shop being in the incorrect location in the minimap.
- Fixed the Demon Edge being buyable twice, softlocking the player.
- Fixed Daedalus & Recipe softlocking if the courier buys the items instead of the player.
- Fixed items staying on stash/courier if skipping mid-section.
- Fixed the path arrow of the last location being weird.
- Other slight fixes to assist with the flow.

Fixes https://github.com/ModDota/dota-tutorial/issues/263