### PR TITLE
Required state: ability cooldowns and Elder Dragon Form

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -373,8 +373,6 @@ const onStart = (complete: () => void) => {
                         for (const item of items) {
                             playerHero.RemoveItem(item);
                         }
-                        playerHero.RemoveModifierByName("modifier_dragon_knight_dragon_form")
-                        playerHero.RemoveModifierByName("modifier_dragon_knight_corrosive_breath")
                         playerHero.RemoveModifierByName(modifier_dk_attack_tower_chapter2.name)
                     }),
                     tg.audioDialog(LocalizationKey.Script_2_Tower_18, LocalizationKey.Script_2_Tower_18, context => context[CustomNpcKeys.SlacksMudGolem]),
@@ -405,8 +403,6 @@ const onStop = () => {
 
     const playerHero = getPlayerHero()
     if (playerHero) {
-        playerHero.RemoveModifierByName("modifier_dragon_knight_dragon_form")
-        playerHero.RemoveModifierByName("modifier_dragon_knight_corrosive_breath")
         playerHero.RemoveModifierByName(modifier_dk_death_chapter2_tower.name)
         playerHero.RemoveModifierByName(modifier_dk_attack_tower_chapter2.name)
     }

--- a/game/scripts/vscripts/Sections/Chapter5/SectionTeamFight.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionTeamFight.ts
@@ -28,6 +28,7 @@ const requiredState: RequiredState = {
         shared.chapter5Blockades.midRiverTopSide,
         shared.chapter5Blockades.roshan,
     ],
+    removeElderDragonForm: false
 }
 
 const radiantFountainLocation = Vector(-6850, -6500, 384)
@@ -54,6 +55,10 @@ function onStart(complete: () => void) {
 
     graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
+            tg.immediate(_ => {
+                playerHero.SetHealth(playerHero.GetMaxHealth())
+                playerHero.SetMana(playerHero.GetMaxMana())
+            }),
             tg.panCameraLinear(_ => getPlayerCameraLocation(), _ => playerHero.GetAbsOrigin(), 1),
             shared.spawnFriendlyHeroes(shared.outsidePitLocation),
             shared.spawnEnemyHeroes(shared.enemyLocation),

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -28,6 +28,9 @@ export type RequiredState = {
     requireODPixelGolem?: boolean
     odPixelLocation?: Vector
 
+    // Elder Dragon Form
+    removeElderDragonForm?: boolean,
+
     // Towers
     topDireT1TowerStanding?: boolean
 
@@ -87,8 +90,9 @@ export const defaultRequiredState: FilledRequiredState = {
     slacksLocation: Vector(-7000, 600, 128),
     requireODPixelGolem: false,
     odPixelLocation: Vector(-7000, 600, 128),
-    
 
+    // Elder Dragon Form
+    removeElderDragonForm: true,
 
     // Towers
     topDireT1TowerStanding: true,

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -24,6 +24,8 @@ export const setupState = (stateReq: RequiredState): void => {
     handleRequiredRespawn(state)
     handleItemsOnGround()
     handlePlantedWards(state)
+    handleAbilityCooldowns(hero)
+    handleElderDragonForm(state.removeElderDragonForm, hero)
 
     handleUnits(state)
     handleFountainTrees(state)
@@ -472,6 +474,7 @@ function handleItemsOnGround() {
         }
     }
 }
+
 function handlePlantedWards(state: FilledRequiredState) {
     if (state.clearWards) {
         const obsWards = Entities.FindAllByClassname("npc_dota_ward_base")
@@ -481,6 +484,26 @@ function handlePlantedWards(state: FilledRequiredState) {
             if (IsValidEntity(ward)) {
                 UTIL_Remove(ward)
             }
+        }
+    }
+}
+
+function handleAbilityCooldowns(hero: CDOTA_BaseNPC_Hero) {
+    for (let index = 0; index < hero.GetAbilityCount(); index++) {
+        const ability = hero.GetAbilityByIndex(index)
+        if (ability && !ability.IsCooldownReady()) {
+            ability.EndCooldown()
+        }
+    }
+}
+
+function handleElderDragonForm(removeElderDragonForm: boolean, hero: CDOTA_BaseNPC_Hero) {
+    if (!removeElderDragonForm) return;
+
+    const modifiers = ["modifier_dragon_knight_dragon_form", "modifier_dragon_knight_corrosive_breath", "modifier_dragon_knight_splash_attack", "modifier_dragon_knight_frost_breath"]
+    for (const modifier of modifiers) {
+        if (hero.HasModifier(modifier)) {
+            hero.RemoveModifierByName(modifier)
         }
     }
 }


### PR DESCRIPTION
- The hero's abilities now refreshes their cooldown when transitioning between sections.
- The hero now loses Elder Dragon Form's modifiers when transitioning between sections. This excludes the transition from Roshan's section to the Teamfight section.
- Removed the manual removal of the Elder Dragon Form from Section Tower (handled in required state now).
- The hero now recovers health and mana at the start of the teamfight section.

Fixes https://github.com/ModDota/dota-tutorial/issues/341