### PR TITLE
Add more validity checks to ch5 roshan

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -96,7 +96,7 @@ function onStart(complete: () => void) {
                 else {
                     error("Hero talents/abilities not found!")
                 }
-            }, 2),
+            }, 0.2),
             tg.immediate(() => goalUpgradeTalents.complete()),
             tg.audioDialog(LocalizationKey.Script_5_Roshan_5, LocalizationKey.Script_5_Roshan_5, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
             tg.immediate(() => {
@@ -122,7 +122,7 @@ function onStart(complete: () => void) {
             tg.setCameraTarget(undefined),
             tg.immediate(_ => centerCameraOnHero()),
             tg.audioDialog(LocalizationKey.Script_5_Roshan_6, LocalizationKey.Script_5_Roshan_6, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
-            tg.completeOnCheck(() => !unitIsValidAndAlive(roshan), 2),
+            tg.completeOnCheck(() => !unitIsValidAndAlive(roshan), 0.2),
             tg.immediate(() => {
                 goalDefeatRoshan.complete()
                 StopGlobalSound(roshanMusic)
@@ -148,7 +148,7 @@ function onStart(complete: () => void) {
                 goalPickupAegis.start()
                 canPlayerIssueOrders = true
             }),
-            tg.completeOnCheck(() => playerHero.HasItemInInventory(shared.itemAegis), 2),
+            tg.completeOnCheck(() => playerHero.HasItemInInventory(shared.itemAegis), 0.2),
             tg.immediate(() => goalPickupAegis.complete()),
             tg.audioDialog(LocalizationKey.Script_5_Roshan_8, LocalizationKey.Script_5_Roshan_8, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
 

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -2,7 +2,7 @@ import { GoalTracker } from "../../Goals";
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerCameraLocation, getPlayerHero, setUnitPacifist } from "../../util";
+import { centerCameraOnHero, findRealPlayerID, getOrError, getPlayerCameraLocation, getPlayerHero, setUnitPacifist, unitIsValidAndAlive } from "../../util";
 import * as shared from "./Shared";
 import { chapter5Blockades, friendlyHeroesInfo, runeSpawnsLocations } from "./Shared";
 
@@ -104,15 +104,17 @@ function onStart(complete: () => void) {
                 goalDefeatRoshan.start()
             }),
             tg.playGlobalSound(roshanMusic),
-            tg.completeOnCheck(() => {
-                return roshan.IsAttacking()
-            }, 0.5),
+            tg.completeOnCheck(() => !unitIsValidAndAlive(roshan) || roshan.IsAttacking(), 0.5),
             shared.spawnFriendlyHeroes(Vector(-2000, 1550, 0)),
             tg.wait(1),
             tg.immediate(context => {
-                for (const friendlyHero of friendlyHeroesInfo) {
-                    const hero: CDOTA_BaseNPC_Hero = context[friendlyHero.name]
-                    hero.SetForceAttackTarget(roshan)
+                if (unitIsValidAndAlive(roshan)) {
+                    for (const friendlyHero of friendlyHeroesInfo) {
+                        const hero: CDOTA_BaseNPC_Hero = context[friendlyHero.name]
+                        if (unitIsValidAndAlive(hero)) {
+                            hero.SetForceAttackTarget(roshan)
+                        }
+                    }
                 }
             }),
             tg.setCameraTarget(context => context[friendlyHeroesInfo[0].name]),
@@ -120,9 +122,7 @@ function onStart(complete: () => void) {
             tg.setCameraTarget(undefined),
             tg.immediate(_ => centerCameraOnHero()),
             tg.audioDialog(LocalizationKey.Script_5_Roshan_6, LocalizationKey.Script_5_Roshan_6, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
-            tg.completeOnCheck(() => {
-                return !roshan.IsAlive()
-            }, 2),
+            tg.completeOnCheck(() => !unitIsValidAndAlive(roshan), 2),
             tg.immediate(() => {
                 goalDefeatRoshan.complete()
                 StopGlobalSound(roshanMusic)


### PR DESCRIPTION
Got this error before while doing Roshan section tabbed out

> Script Runtime Error: scripts\vscripts\Sections/Chapter5/SectionRoshan.ts:124: Can't call CDOTA_BaseNPC:IsAlive on an object of type [none]
stack traceback:
    [C]: at 0x7ffea3b98140
    [C]: in function 'IsAlive'
    scripts\vscripts\Sections/Chapter5/SectionRoshan.ts:124: in function 'checkFn'
    scripts\vscripts\TutorialGraph/Steps.ts:613: in function 'check'
    scripts\vscripts\TutorialGraph/Steps.ts:620: in function 'start'
    scripts\vscripts\TutorialGraph/Core.ts:134: in function 'complete'
    scripts\vscripts\TutorialGraph/Steps.ts:713: in function 'dialogEndedCallback'
    scripts\vscripts\Dialog.ts:136: in function <scripts\vscripts\Dialog.lua:93>

so I added some more alive and valid checks for roshan