### PR TITLE
Required State for T2 tower, Chapter 4 Outpost fixes

### DIFF
--- a/common/general.d.ts
+++ b/common/general.d.ts
@@ -35,6 +35,7 @@ declare const enum CustomNpcKeys {
     TargetDummy = "npc_dota_tutorial_target_dummy",
     PurgePugna = "npc_dota_hero_pugna",
     DireTopT1Tower = "npc_dota_badguys_tower1_top",
+    DireTopT2Tower = "npc_dota_badguys_tower2_top",
     Sniper = "npc_dota_hero_sniper",
     Juggernaut = "npc_dota_hero_juggernaut",
     Zuus = "npc_dota_hero_zuus",

--- a/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
+++ b/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
@@ -151,6 +151,7 @@ const requiredState: RequiredState = {
         new Blockade(Vector(-4480, 4630), Vector(-4597, 3497)),
         new Blockade(Vector(-1450, 4600), Vector(-1500, 3300)),
     ],
+    topDireT1TowerStanding: false
 }
 
 const stack = (count: number, neutralDetector: NeutralDetector, onStacked: (tries: number, stacks: number) => tg.TutorialStep, onFailure: (tries: number, stacks: number) => tg.TutorialStep) => {

--- a/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
@@ -1,9 +1,9 @@
-import * as tut from "../../Tutorial/Core";
-import * as tg from "../../TutorialGraph/index";
-import * as shared from "./Shared"
-import { RequiredState } from "../../Tutorial/RequiredState";
-import { freezePlayerHero, getOrError, getPlayerCameraLocation, getPlayerHero, removeContextEntityIfExists } from "../../util";
 import { GoalTracker } from "../../Goals";
+import * as tut from "../../Tutorial/Core";
+import { RequiredState } from "../../Tutorial/RequiredState";
+import * as tg from "../../TutorialGraph/index";
+import { freezePlayerHero, getOrError, getPlayerCameraLocation, getPlayerHero, removeContextEntityIfExists } from "../../util";
+import * as shared from "./Shared";
 
 const sectionName: SectionName = SectionName.Chapter4_Communication;
 
@@ -17,7 +17,9 @@ const requiredState: RequiredState = {
     heroAbilityMinLevels: [1, 1, 1, 1],
     heroItems: { "item_greater_crit": 1 },
     blockades: Object.values(shared.blockades),
-    clearWards: false
+    clearWards: false,
+    topDireT1TowerStanding: false,
+    topDireT2TowerStanding: false
 };
 
 const allyHeroStartLocation = Vector(-3000, 3800, 128);
@@ -186,5 +188,5 @@ export const sectionCommunication = new tut.FunctionalSection(
     sectionName,
     requiredState,
     onStart,
-    onStop
+    onStop,
 );

--- a/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
@@ -21,6 +21,7 @@ const requiredState: RequiredState = {
     requireRiki: true,
     rikiLocation: Vector(-1800, 4000, 256),
     blockades: Object.values(shared.blockades),
+    topDireT1TowerStanding: false
 };
 
 let canPlayerIssueOrders = true;

--- a/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
@@ -19,6 +19,7 @@ const requiredState: RequiredState = {
     requireRiki: true,
     rikiLocation: Vector(-1800, 4000, 256),
     blockades: Object.values(shared.blockades),
+    topDireT1TowerStanding: false
 };
 
 const markerLocation = Vector(-2200, 3700, 256);

--- a/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
@@ -1,11 +1,10 @@
-import * as tut from "../../Tutorial/Core";
-import * as tg from "../../TutorialGraph/index";
-import { RequiredState } from "../../Tutorial/RequiredState";
 import { GoalTracker } from "../../Goals";
+import * as tut from "../../Tutorial/Core";
+import { RequiredState } from "../../Tutorial/RequiredState";
+import * as tg from "../../TutorialGraph/index";
 import { centerCameraOnHero, DirectionToPosition, findRealPlayerID, getOrError, getPlayerCameraLocation, getPlayerHero, setUnitPacifist, unitIsValidAndAlive, useAbility } from "../../util";
-import * as shared from "./Shared"
+import * as shared from "./Shared";
 import { HeroInfo } from "./Shared";
-import { TutorialContext } from "../../TutorialGraph/index";
 
 const sectionName: SectionName = SectionName.Chapter5_Opening;
 
@@ -35,6 +34,8 @@ const requiredState: RequiredState = {
     requireBountyRunes: true,
     requireRoshan: true,
     roshanHitsLikeATruck: true,
+    topDireT1TowerStanding: false,
+    topDireT2TowerStanding: false,
 };
 
 const powerRuneRangersInfo: HeroInfo[] = [

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -30,7 +30,9 @@ const requiredState: RequiredState = {
         chapter5Blockades.direMidTopRiver,
         chapter5Blockades.midRiverTopSide,
     ],
-    requireRoshan: true
+    requireRoshan: true,
+    topDireT1TowerStanding: false,
+    topDireT2TowerStanding: false,
 };
 
 const roshanMusic = "valve_ti10.music.roshan"

--- a/game/scripts/vscripts/Sections/Chapter5/SectionTeamFight.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionTeamFight.ts
@@ -28,7 +28,9 @@ const requiredState: RequiredState = {
         shared.chapter5Blockades.midRiverTopSide,
         shared.chapter5Blockades.roshan,
     ],
-    removeElderDragonForm: false
+    removeElderDragonForm: false,
+    topDireT1TowerStanding: false,
+    topDireT2TowerStanding: false
 }
 
 const radiantFountainLocation = Vector(-6850, -6500, 384)

--- a/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
+++ b/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
@@ -27,6 +27,8 @@ const requiredState: RequiredState = {
         "item_heart": 1,
         "item_aegis": 1,
     },
+    topDireT1TowerStanding: false,
+    topDireT2TowerStanding: false
 }
 
 const INTERACTION_DISTANCE = 200;
@@ -106,7 +108,7 @@ const npcs = [
     new ClosingNpc(CustomNpcKeys.Perry, Vector(-7050, -4700, 256), LocalizationKey.Script_6_Perry),
     new ClosingNpc(CustomNpcKeys.PongPing, Vector(-6750, -4400, 256), LocalizationKey.Script_6_PongPing),
     new ClosingNpc(CustomNpcKeys.Shush, Vector(-6450, -4400, 256), LocalizationKey.Script_6_Shush),
-    new ClosingNpc(CustomNpcKeys.SinZ,Vector(-6150, -4400, 256), LocalizationKey.Script_6_SinZ),
+    new ClosingNpc(CustomNpcKeys.SinZ, Vector(-6150, -4400, 256), LocalizationKey.Script_6_SinZ),
     new ClosingNpc(CustomNpcKeys.SmashTheState, Vector(-5850, -4700, 256), LocalizationKey.Script_6_SmashTheState),
     new ClosingNpc(CustomNpcKeys.Tora, Vector(-5850, -5000, 256), LocalizationKey.Script_6_Tora),
     new ClosingNpc(CustomNpcKeys.Toyoka, Vector(-7050, -5000, 256), LocalizationKey.Script_6_Toyoka),
@@ -221,7 +223,7 @@ function sectionTimerUpdate() {
 }
 
 function orderFilter(order: ExecuteOrderFilterEvent) {
-    if(!order.entindex_target) {
+    if (!order.entindex_target) {
         talkTarget = undefined;
         return true;
     }

--- a/game/scripts/vscripts/Sections/Chapter6/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter6/SectionOpening.ts
@@ -21,6 +21,8 @@ const requiredState: RequiredState = {
         "item_heart": 1,
         "item_aegis": 1,
     },
+    topDireT1TowerStanding: false,
+    topDireT2TowerStanding: false
 };
 
 const axeName = CustomNpcKeys.Axe;

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -33,6 +33,7 @@ export type RequiredState = {
 
     // Towers
     topDireT1TowerStanding?: boolean
+    topDireT2TowerStanding?: boolean
 
     // Riki
     requireRiki?: boolean
@@ -96,6 +97,7 @@ export const defaultRequiredState: FilledRequiredState = {
 
     // Towers
     topDireT1TowerStanding: true,
+    topDireT2TowerStanding: true,
 
     // Riki
     requireRiki: false,

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -305,6 +305,29 @@ function handleRequiredItems(state: FilledRequiredState, hero: CDOTA_BaseNPC_Her
     else if (direTop && IsValidEntity(direTop) && direTop.IsAlive()) {
         UTIL_Remove(direTop)
     }
+
+    const direTopTower2Location = Vector(0, 6016, 128)
+    let direTop2 = Entities.FindByClassnameNearest("npc_dota_tower", direTopTower2Location, 200) as CDOTA_BaseNPC_Building
+    if (state.topDireT2TowerStanding) {
+        if (!direTop2 || !IsValidEntity(direTop2) || !direTop2.IsAlive()) {
+            direTop = CreateUnitByName(CustomNpcKeys.DireTopT2Tower, direTopTower2Location, false, undefined, undefined, DotaTeam.BADGUYS) as CDOTA_BaseNPC_Building
+            direTop.AddNewModifier(undefined, undefined, "modifier_tower_truesight_aura", {})
+            direTop.AddNewModifier(undefined, undefined, "modifier_tower_aura", {})
+            direTop.RemoveModifierByName("modifier_invulnerable")
+            direTop.SetRenderColor(65, 78, 63)
+        }
+    }
+    else if (direTop2 && IsValidEntity(direTop2) && direTop2.IsAlive()) {
+        ApplyDamage({
+            attacker: direTop2,
+            victim: direTop2,
+            damage: direTop2.GetMaxHealth(),
+            damage_type: DamageTypes.PURE,
+            damage_flags: DamageFlag.BYPASSES_INVULNERABILITY + DamageFlag.HPLOSS
+        })
+
+        UTIL_Remove(direTop2)
+    }
 }
 
 function handleRequiredRespawn(state: FilledRequiredState) {


### PR DESCRIPTION
- Added a requiredSetup for T2 dire top towers, defaults to true, whether the tower should be alive.
- When returning false on the T2 dire top tower, it is first killed by taking massive damage (releasing the outpost control), then it is removed from the game, effectively removing the destruction sound and announcer.
- Added T1 and T2 tower required states to all sections as appropriate. T1 stands until CH2 Tower, and T2 stands until CH4 Outpost. All sections after it kill both towers.
- Fixed an issue where the Outpost remained Radiant's when repeating CH4 Outpost.
- Fixed an issue that allowed you to take the Outpost early.
- Removed some unnecessary lines.

Fixes https://github.com/ModDota/dota-tutorial/issues/154
Fixes https://github.com/ModDota/dota-tutorial/issues/234
