### PR TITLE
Greevils begone

### DIFF
--- a/game/scripts/vscripts/Dialog.ts
+++ b/game/scripts/vscripts/Dialog.ts
@@ -1,3 +1,4 @@
+import { modifier_particle_attach } from "./modifiers/modifier_particle_attach";
 import { getSoundDuration } from "./Sounds";
 import { getOrError, getPlayerHero, highlight } from "./util";
 
@@ -40,8 +41,14 @@ class DialogController {
     private clearParticles() {
         if (this.particles !== undefined) {
             for (const particleIndex of this.particles) {
-                ParticleManager.DestroyParticle(particleIndex, false);
-                ParticleManager.ReleaseParticleIndex(particleIndex);
+                if (this.currentLine && this.currentLine.speaker) {
+                    for (const modifier of this.currentLine.speaker.FindAllModifiersByName(modifier_particle_attach.name)) {
+                        if ((modifier as modifier_particle_attach).particleID === particleIndex) {
+                            modifier.Destroy()
+                            break;
+                        }
+                    }
+                }
             }
             this.particles = undefined;
         }

--- a/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionCreeps.ts
@@ -15,8 +15,6 @@ const requiredState: RequiredState = {
     heroLocationTolerance: 300,
     requireSlacksGolem: true,
     requireSunsfanGolem: true,
-    slacksLocation: Vector(-5495, 2930, 128),
-    sunsFanLocation: Vector(-5515, 2700, 128),
     heroAbilityMinLevels: [1, 1, 1, 0],
     heroLevel: 3,
     blockades: [

--- a/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionOpening.ts
@@ -23,8 +23,6 @@ const requiredState: RequiredState = {
     heroLocationTolerance: 1500,
     requireSlacksGolem: true,
     requireSunsfanGolem: true,
-    slacksLocation: Vector(-5906, -3892, 256),
-    sunsFanLocation: Vector(-5500, -4170, 256),
     heroAbilityMinLevels: [1, 1, 1, 0],
     heroLevel: 3,
     blockades: [

--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -26,8 +26,6 @@ const requiredState: RequiredState = {
     heroLocationTolerance: 800,
     requireSlacksGolem: true,
     requireSunsfanGolem: true,
-    slacksLocation: Vector(-5906, -3892, 256),
-    sunsFanLocation: Vector(-5500, -4170, 256),
     heroAbilityMinLevels: [1, 1, 1, 0],
     heroLevel: 3,
     blockades: [

--- a/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
@@ -15,8 +15,6 @@ const requiredState: RequiredState = {
     heroLocationTolerance: 1800, // prevent teleportations if you're still in the vicinity
     requireSlacksGolem: true,
     requireSunsfanGolem: true,
-    slacksLocation: Vector(-5495, 2930, 128),
-    sunsFanLocation: Vector(-5515, 2700, 128),
     heroAbilityMinLevels: [1, 1, 1, 1],
     heroLevel: 6,
     blockades: [

--- a/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionOpening.ts
@@ -223,6 +223,13 @@ function onStart(complete: () => void) {
 function onStop() {
     print("Stopping", sectionName);
     removeHighlight(scanUIPath);
+
+    const playerHero = getOrError(getPlayerHero())
+
+    if (waitingForPlayerToScan) {
+        MinimapEvent(DotaTeam.GOODGUYS, playerHero, Vector(0, 0, 0).x, Vector(0, 0, 0).y, MinimapEventType.TUTORIAL_TASK_FINISHED, 0.1)
+    }
+
     if (graph) {
         graph.stop(GameRules.Addon.context);
         disposeCreeps();

--- a/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
@@ -14,8 +14,6 @@ let canPlayerIssueOrders = false;
 const requiredState: RequiredState = {
     requireSlacksGolem: true,
     requireSunsfanGolem: true,
-    slacksLocation: Vector(-5906, -3892, 256),
-    sunsFanLocation: Vector(-5500, -4170, 256),
     heroLocation: Vector(-4150, 2568, 0),
     heroLocationTolerance: 800,
     heroLevel: 6,

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -14,8 +14,6 @@ let canPlayerIssueOrders = false;
 const requiredState: RequiredState = {
     requireSlacksGolem: true,
     requireSunsfanGolem: true,
-    slacksLocation: Vector(-5906, -3892, 256),
-    sunsFanLocation: Vector(-5500, -4170, 256),
     heroLocation: runeSpawnsLocations.topPowerUpRunePos.__add(Vector(-200, 0, -48)),
     heroLocationTolerance: 2000,
     heroLevel: 6,

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -85,11 +85,11 @@ export const defaultRequiredState: FilledRequiredState = {
 
     // Golems
     requireSunsfanGolem: false,
-    sunsFanLocation: Vector(-7000, 600, 128),
+    sunsFanLocation: Vector(0, 0, 0),
     requireSlacksGolem: false,
-    slacksLocation: Vector(-7000, 600, 128),
+    slacksLocation: Vector(0, 0, 0),
     requireODPixelGolem: false,
-    odPixelLocation: Vector(-7000, 600, 128),
+    odPixelLocation: Vector(0, 0, 0),
 
     // Elder Dragon Form
     removeElderDragonForm: true,

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -107,7 +107,16 @@ function handleBlockades(state: FilledRequiredState) {
 function handleUnits(state: FilledRequiredState) {
     // Golems
     const golemPostCreate = (unit: CDOTA_BaseNPC, created: boolean) => {
-        if (!created) {
+        const shouldGolemBeHidden = unit.GetAbsOrigin() === Vector(0, 0, 0);
+
+        if (shouldGolemBeHidden) {
+            unit.SetTeam(DotaTeam.BADGUYS)
+            unit.AddNewModifier(undefined, undefined, "modifier_invisible", {})
+            setUnitPacifist(unit, false);
+            return
+        }
+        else if (!created) {
+            if (unit.HasModifier("modifier_invisible")) unit.RemoveModifierByName("modifier_invisible")
             setUnitPacifist(unit, false);
             unit.SetTeam(DotaTeam.GOODGUYS);
         }

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -114,8 +114,7 @@ function handleUnits(state: FilledRequiredState) {
             unit.AddNewModifier(undefined, undefined, "modifier_invisible", {})
             setUnitPacifist(unit, false);
             return
-        }
-        else if (!created) {
+        } else if (!created) {
             if (unit.HasModifier("modifier_invisible")) unit.RemoveModifierByName("modifier_invisible")
             setUnitPacifist(unit, false);
             unit.SetTeam(DotaTeam.GOODGUYS);

--- a/game/scripts/vscripts/modifiers/modifier_particle_attach.ts
+++ b/game/scripts/vscripts/modifiers/modifier_particle_attach.ts
@@ -2,6 +2,8 @@ import { BaseModifier, registerModifier } from "../lib/dota_ts_adapter";
 
 @registerModifier()
 export class modifier_particle_attach extends BaseModifier {
+    particleID?: ParticleID
+
     GetAttributes() { return ModifierAttribute.MULTIPLE }
 
     IsHidden() { return true }

--- a/game/scripts/vscripts/util.ts
+++ b/game/scripts/vscripts/util.ts
@@ -3,6 +3,7 @@ import "./modifiers/modifier_tutorial_pacifist"
 import "./modifiers/modifier_dummy"
 import "./modifiers/modifier_particle_attach"
 import { TutorialContext } from "./TutorialGraph/Core";
+import { modifier_particle_attach } from "./modifiers/modifier_particle_attach";
 
 let respawnListener: EventListenerID | undefined
 
@@ -322,8 +323,9 @@ export const createParticleAtLocation = (particleName: string, location: Vector)
  */
 export const createParticleAttachedToUnit = (particleName: string, unit: CDOTA_BaseNPC, attach: ParticleAttachment = ParticleAttachment.ABSORIGIN_FOLLOW) => {
     const particleID = ParticleManager.CreateParticle(particleName, attach, unit)
-    const modifier = unit.AddNewModifier(undefined, undefined, "modifier_particle_attach", {})
+    const modifier = unit.AddNewModifier(undefined, undefined, modifier_particle_attach.name, {}) as modifier_particle_attach
     if (modifier) {
+        modifier.particleID = particleID;
         modifier.AddParticle(particleID, false, false, -1, false, false);
     }
 


### PR DESCRIPTION
- Greevils are actually hidden now when no vector is defined in the requiredState. They are now set to dire team whenever that's the case, are pacifists, and get the invisibility modifier. They also properly change teams back and are stripped from the invisibility when chapters use them again (e.g. CH1, CH6). They cannot be found in the map, not even by a scan.
- Fixed an issue that caused a modifier to accumulate on each unit that talked, each time it talked, which led to potential issues. Instead, now modifiers are removed based on their attached particle IDs.
- Fixed an issue that was randomly found, where CH4 scans minimap events remain on the map when skipping to another section.