### PR TITLE
Fix outpost change team, required state

### DIFF
--- a/game/scripts/vscripts/Dialog.ts
+++ b/game/scripts/vscripts/Dialog.ts
@@ -42,10 +42,12 @@ class DialogController {
         if (this.particles !== undefined) {
             for (const particleIndex of this.particles) {
                 if (this.currentLine && this.currentLine.speaker) {
-                    for (const modifier of this.currentLine.speaker.FindAllModifiersByName(modifier_particle_attach.name)) {
-                        if ((modifier as modifier_particle_attach).particleID === particleIndex) {
-                            modifier.Destroy()
-                            break;
+                    if (IsValidEntity(this.currentLine.speaker)) {
+                        for (const modifier of this.currentLine.speaker.FindAllModifiersByName(modifier_particle_attach.name)) {
+                            if ((modifier as modifier_particle_attach).particleID === particleIndex) {
+                                modifier.Destroy()
+                                break;
+                            }
                         }
                     }
                 }

--- a/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
@@ -19,7 +19,8 @@ const requiredState: RequiredState = {
     blockades: Object.values(shared.blockades),
     clearWards: false,
     topDireT1TowerStanding: false,
-    topDireT2TowerStanding: false
+    topDireT2TowerStanding: false,
+    outpostTeam: DotaTeam.GOODGUYS
 };
 
 const allyHeroStartLocation = Vector(-3000, 3800, 128);

--- a/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionOpening.ts
@@ -35,6 +35,7 @@ const requiredState: RequiredState = {
     topDireT1TowerStanding: false,
     topDireT2TowerStanding: false,
     heroItems: { [shared.itemDaedalus]: 1 },
+    outpostTeam: DotaTeam.GOODGUYS,
 };
 
 const powerRuneRangersInfo: HeroInfo[] = [

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -31,6 +31,7 @@ const requiredState: RequiredState = {
     requireRoshan: true,
     topDireT1TowerStanding: false,
     topDireT2TowerStanding: false,
+    outpostTeam: DotaTeam.GOODGUYS,
     heroItems: { [shared.itemDaedalus]: 1 },
 };
 

--- a/game/scripts/vscripts/Sections/Chapter5/SectionTeamFight.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionTeamFight.ts
@@ -30,7 +30,8 @@ const requiredState: RequiredState = {
     ],
     removeElderDragonForm: false,
     topDireT1TowerStanding: false,
-    topDireT2TowerStanding: false
+    topDireT2TowerStanding: false,
+    outpostTeam: DotaTeam.GOODGUYS,
 }
 
 const radiantFountainLocation = Vector(-6850, -6500, 384)

--- a/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
+++ b/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
@@ -28,7 +28,8 @@ const requiredState: RequiredState = {
         "item_aegis": 1,
     },
     topDireT1TowerStanding: false,
-    topDireT2TowerStanding: false
+    topDireT2TowerStanding: false,
+    outpostTeam: DotaTeam.GOODGUYS,
 }
 
 const INTERACTION_DISTANCE = 200;

--- a/game/scripts/vscripts/Sections/Chapter6/SectionOpening.ts
+++ b/game/scripts/vscripts/Sections/Chapter6/SectionOpening.ts
@@ -22,7 +22,8 @@ const requiredState: RequiredState = {
         "item_aegis": 1,
     },
     topDireT1TowerStanding: false,
-    topDireT2TowerStanding: false
+    topDireT2TowerStanding: false,
+    outpostTeam: DotaTeam.GOODGUYS,
 };
 
 const axeName = CustomNpcKeys.Axe;

--- a/game/scripts/vscripts/Tutorial/RequiredState.ts
+++ b/game/scripts/vscripts/Tutorial/RequiredState.ts
@@ -35,6 +35,9 @@ export type RequiredState = {
     topDireT1TowerStanding?: boolean
     topDireT2TowerStanding?: boolean
 
+    // Outpost
+    outpostTeam?: DotaTeam
+
     // Riki
     requireRiki?: boolean
     rikiLocation?: Vector
@@ -98,6 +101,9 @@ export const defaultRequiredState: FilledRequiredState = {
     // Towers
     topDireT1TowerStanding: true,
     topDireT2TowerStanding: true,
+
+    // Outpost
+    outpostTeam: DotaTeam.BADGUYS,
 
     // Riki
     requireRiki: false,

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -298,7 +298,7 @@ function handleRequiredItems(state: FilledRequiredState, hero: CDOTA_BaseNPC_Her
         }
     }
 
-    // Create the top T1 dier tower if it's down
+    // Create the top T1 dire tower if it's down and needs to be up, or remove it if it needs to be down
     const direTopTowerLocation = Vector(-4672, 6016, 128)
     let direTop = Entities.FindByClassnameNearest("npc_dota_tower", direTopTowerLocation, 200) as CDOTA_BaseNPC_Building
     if (state.topDireT1TowerStanding) {
@@ -314,6 +314,7 @@ function handleRequiredItems(state: FilledRequiredState, hero: CDOTA_BaseNPC_Her
         UTIL_Remove(direTop)
     }
 
+    // Create the top T2 dire tower if it's down and needs to be up, or remove it if it needs to be down
     const direTopTower2Location = Vector(0, 6016, 128)
     let direTop2 = Entities.FindByClassnameNearest("npc_dota_tower", direTopTower2Location, 200) as CDOTA_BaseNPC_Building
     if (state.topDireT2TowerStanding) {
@@ -335,6 +336,16 @@ function handleRequiredItems(state: FilledRequiredState, hero: CDOTA_BaseNPC_Her
         })
 
         UTIL_Remove(direTop2)
+    }
+
+    const topOutpost = getOrError(Entities.FindByName(undefined, "npc_dota_watch_tower_top")) as CDOTA_BaseNPC
+    if (topOutpost.GetTeamNumber() !== state.outpostTeam) {
+        topOutpost.SetTeam(state.outpostTeam)
+        if (state.outpostTeam === DotaTeam.BADGUYS) {
+            if (topOutpost.HasModifier("modifier_invulnerable")) {
+                topOutpost.RemoveModifierByName("modifier_invulnerable")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Fix issue with dialog that occurs when attempting to remove the blue dialog circle from a unit that was deleted
- Fix issue with Outposts not letting you take them.
- Put Outpost in requiredState, default DotaTeam.BADGUYS, set DotaTeam.GOODGUYS on sectionOutpost onwards.