### PR TITLE
Kunkka no stuck

### DIFF
--- a/common/localization.d.ts
+++ b/common/localization.d.ts
@@ -421,5 +421,7 @@ declare const enum LocalizationKey {
     Error_Wards_5 = "Error_Wards_5",
     Error_Wards_6 = "Error_Wards_6",
     Error_Wards_7 = "Error_Wards_7",
+    Error_Communications_1 = "Error_Communications_1",
+    Error_Communications_2 = "Error_Communications_2",
     Error_Teamfight_1 = "Error_Teamfight_1",
 }

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -86,6 +86,8 @@
         "Error_Wards_5"        "Moving items is currently disabled."
         "Error_Wards_6"        "Toggling items is currently disabled."
         "Error_Wards_7"        "Locking or combining items is currently disabled."
+        "Error_Communications_1" "You cannot pick up item in this section."
+        "Error_Communications_2" "You cannot destroy items in this section."
         "Error_Teamfight_1"    "Teleport to your fountain by double-tapping the Town Portal Scroll."
 
         // Goals

--- a/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionCommunication.ts
@@ -2,7 +2,7 @@ import { GoalTracker } from "../../Goals";
 import * as tut from "../../Tutorial/Core";
 import { RequiredState } from "../../Tutorial/RequiredState";
 import * as tg from "../../TutorialGraph/index";
-import { freezePlayerHero, getOrError, getPlayerCameraLocation, getPlayerHero, removeContextEntityIfExists } from "../../util";
+import { displayDotaErrorMessage, findRealPlayerID, freezePlayerHero, getOrError, getPlayerCameraLocation, getPlayerHero, removeContextEntityIfExists } from "../../util";
 import * as shared from "./Shared";
 
 const sectionName: SectionName = SectionName.Chapter4_Communication;
@@ -116,7 +116,6 @@ function onStart(complete: () => void) {
             tg.audioDialog(LocalizationKey.Script_4_Communication_15, LocalizationKey.Script_4_Communication_15, ctx => ctx[CustomNpcKeys.SlacksMudGolem]),
 
             // Kunkka destroy items
-            tg.immediate(_ => freezePlayerHero(true)),
             tg.setCameraTarget(context => context[kunkkaName]),
             tg.fork([
                 tg.audioDialog(LocalizationKey.Script_4_mason_mad, LocalizationKey.Script_4_mason_mad, ctx => ctx[kunkkaName]),
@@ -151,8 +150,6 @@ function onStart(complete: () => void) {
             tg.immediate(context => context[kunkkaName].StartGesture(GameActivity.DOTA_GENERIC_CHANNEL_1)),
             tg.moveUnit(context => context[kunkkaName], allyHeroStartLocation),
             tg.immediate(context => context[kunkkaName].FadeGesture(GameActivity.DOTA_GENERIC_CHANNEL_1)),
-
-            tg.immediate(_ => freezePlayerHero(false)),
             tg.setCameraTarget(undefined),
 
             tg.audioDialog(LocalizationKey.Script_4_Communication_16, LocalizationKey.Script_4_Communication_16, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
@@ -190,4 +187,21 @@ export const sectionCommunication = new tut.FunctionalSection(
     requiredState,
     onStart,
     onStop,
+    orderFilter
 );
+
+function orderFilter(event: ExecuteOrderFilterEvent) {
+    if (event.issuer_player_id_const == findRealPlayerID()) {
+        if (event.order_type == UnitOrder.PICKUP_ITEM) {
+            displayDotaErrorMessage(LocalizationKey.Error_Communications_1)
+            return false
+        }
+
+        if (event.order_type === UnitOrder.ATTACK_TARGET) {
+            displayDotaErrorMessage(LocalizationKey.Error_Communications_2)
+            return false
+        }
+    }
+
+    return true
+}


### PR DESCRIPTION
Fixes https://github.com/ModDota/dota-tutorial/issues/377

- The player is no longer frozen in Kunkka's part. This essentially allows the player to move out of the way if Kunkka gets stuck.
- Added an order filter to prevent the player from attacking or picking up items, with proper localizations as well.

Tested naturally and with skips, seems to work fine.