### PR TITLE
Start videos from beginning

### DIFF
--- a/content/panorama/layout/custom_game/videos.xml
+++ b/content/panorama/layout/custom_game/videos.xml
@@ -16,7 +16,7 @@
             <Panel class="BlurBackground" hittest="false" />
             <Panel class="MovieContainerMuting">
                 <Label class="VideoTitle" text="#Muting_Player"/>
-                <MoviePanel class ="CustomMoviePanelMuting" src="s2r://panorama/videos/MutePlayer.webm" repeat="true" autoplay="onload" />
+                <Movie class="CustomMoviePanelMuting TutorialMovie" src="s2r://panorama/videos/MutePlayer.webm" repeat="true" autoplay="onload" />
                 <Button class="VideoContinue" onactivate="OnVideoContinue();">
                     <Label text="#Continue"/>
                 </Button>
@@ -27,7 +27,7 @@
             <Panel class="BlurBackground" hittest="false" />
             <Panel class="MovieContainerGuides">
                 <Label class="VideoTitle" text="#Select_Guide"/>
-                <MoviePanel class ="CustomMoviePanelGuides" src="s2r://panorama/videos/Guides.webm" repeat="true" autoplay="onload" />
+                <Movie class="CustomMoviePanelGuides TutorialMovie" src="s2r://panorama/videos/Guides.webm" repeat="true" autoplay="onload" />
                 <Button class="VideoContinue" onactivate="OnVideoContinue();">
                     <Label text="#Continue"/>
                 </Button>

--- a/content/panorama/scripts/custom_game/videos.ts
+++ b/content/panorama/scripts/custom_game/videos.ts
@@ -20,6 +20,13 @@ function OnPlayVideo(event: PlayVideoEvent) {
             break;
     }
 
+    if (currentVideoPanel) {
+        const moviePanel = currentVideoPanel.FindChildrenWithClassTraverse("TutorialMovie")[0] as MoviePanel;
+        // Restart the movie. Stop() -> Play() didn't work (might with a schedule) but this does.
+        moviePanel.SetReadyForDisplay(false);
+        moviePanel.SetReadyForDisplay(true);
+    }
+
     Game.EmitSound("ui_chat_slide_in");
 }
 


### PR DESCRIPTION
Also renamed MoviePanel to Movie (the latter is the correct one and has the `Play()` etc. functions in js, apparently even Valve has this typo in their things). Fixes #389.