### PR TITLE
Fix golem hiding logic

### DIFF
--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -107,12 +107,12 @@ function handleBlockades(state: FilledRequiredState) {
 function handleUnits(state: FilledRequiredState) {
     // Golems
     const golemPostCreate = (unit: CDOTA_BaseNPC, created: boolean) => {
-        const shouldGolemBeHidden = unit.GetAbsOrigin() === Vector(0, 0, 0);
+        const shouldGolemBeHidden = unit.GetAbsOrigin().__sub(Vector(0, 0, 0)).Length2D() < 100
 
         if (shouldGolemBeHidden) {
             unit.SetTeam(DotaTeam.BADGUYS)
             unit.AddNewModifier(undefined, undefined, "modifier_invisible", {})
-            setUnitPacifist(unit, false);
+            setUnitPacifist(unit, true);
             return
         } else if (!created) {
             if (unit.HasModifier("modifier_invisible")) unit.RemoveModifierByName("modifier_invisible")


### PR DESCRIPTION
Fix `golemShouldBeHidden ` bool not being set properly sometimes in `golemPostCreate `function, should fix dialogs not playing sometimes because slacks greevil wouldn't get the invis or pacifist modifiers, and would sometimes spawn in tower range.