### PR TITLE
Add world-space texts

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -64,6 +64,16 @@ interface CreditsInteractEvent {
     description?: string;
 }
 
+interface AddWorldTextEvent {
+    index: number;
+    text: string;
+    location: { x: number, y: number, z: number };
+}
+
+interface RemoveWorldTextEvent {
+    index: number;
+}
+
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
@@ -88,4 +98,6 @@ interface CustomGameEventDeclarations {
     voice_chat: {};
     credits_interact: CreditsInteractEvent;
     credits_interact_stop: {};
+    add_world_text: AddWorldTextEvent;
+    remove_world_text: RemoveWorldTextEvent;
 }

--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -9,6 +9,7 @@
         <include src="file://{resources}/scripts/custom_game/shop-detection.js" />
     </scripts>
     <Panel>
+        <CustomUIElement type="Hud" layoutfile="file://{resources}/layout/custom_game/world_text.xml" />
         <CustomUIElement type="Hud" layoutfile="file://{resources}/layout/custom_game/dialog.xml" />
         <CustomUIElement type="Hud" layoutfile="file://{resources}/layout/custom_game/hud.xml" />
         <CustomUIElement type="Hud" layoutfile="file://{resources}/layout/custom_game/devpanel.xml" />

--- a/content/panorama/layout/custom_game/world_text.xml
+++ b/content/panorama/layout/custom_game/world_text.xml
@@ -1,0 +1,16 @@
+<root>
+    <styles>
+        <include src="s2r://panorama/styles/dotastyles.css" />
+        <include src="s2r://panorama/styles/hudstyles.vcss_c"/>
+        <include src="s2r://panorama/styles/hud/hud_reborn.vcss_c" />
+
+        <include src="file://{resources}/styles/custom_game/world_text.css" />
+    </styles>
+
+    <scripts>
+        <include src="file://{resources}/scripts/custom_game/world_text.js" />
+    </scripts>
+
+    <Panel hittest="false" class="WorldTextRoot">
+    </Panel>
+</root>

--- a/content/panorama/scripts/custom_game/world_text.ts
+++ b/content/panorama/scripts/custom_game/world_text.ts
@@ -37,8 +37,13 @@ type WorldText = {
                 Game.WorldToScreenY(...location)
             ]
 
-            panel.style.x = `${Math.round(screenLocation[0] * ratio)}px`
-            panel.style.y = `${Math.round(screenLocation[1] * ratio)}px`
+            if (screenLocation[0] !== -1 && screenLocation[1] !== -1) {
+                panel.style.x = `${Math.round(screenLocation[0] * ratio)}px`
+                panel.style.y = `${Math.round(screenLocation[1] * ratio)}px`
+                panel.visible = true
+            } else {
+                panel.visible = false
+            }
         }
 
         $.Schedule(0.01, update);

--- a/content/panorama/scripts/custom_game/world_text.ts
+++ b/content/panorama/scripts/custom_game/world_text.ts
@@ -1,0 +1,51 @@
+type WorldText = {
+    panel: LabelPanel
+    location: [number, number, number]
+}
+
+(() => {
+    const root = $.GetContextPanel();
+    const worldTexts = new Map<number, WorldText>()
+
+    function addWorldText(index: number, text: string, location: [number, number, number]) {
+        const panel = $.CreatePanel("Label", root, "")
+        panel.text = text;
+        panel.AddClass("WorldText")
+
+        worldTexts.set(index, {
+            panel,
+            location,
+        })
+    }
+
+    function removeWorldText(index: number) {
+        const worldText = worldTexts.get(index)
+        if (worldText) {
+            worldTexts.delete(index)
+            worldText.panel.DeleteAsync(0);
+        } else {
+            $.Warning("Tried to delete non-existent world text with index", index)
+        }
+    }
+
+    function update() {
+        const ratio = 1080 / Game.GetScreenHeight();
+
+        for (const { location, panel } of worldTexts.values()) {
+            const screenLocation = [
+                Game.WorldToScreenX(...location),
+                Game.WorldToScreenY(...location)
+            ]
+
+            panel.style.x = `${Math.round(screenLocation[0] * ratio)}px`
+            panel.style.y = `${Math.round(screenLocation[1] * ratio)}px`
+        }
+
+        $.Schedule(0.01, update);
+    }
+
+    GameEvents.Subscribe("add_world_text", event => addWorldText(event.index, event.text, [event.location.x, event.location.y, event.location.z]))
+    GameEvents.Subscribe("remove_world_text", event => removeWorldText(event.index))
+
+    $.Schedule(0.01, update);
+})();

--- a/content/panorama/styles/custom_game/world_text.css
+++ b/content/panorama/styles/custom_game/world_text.css
@@ -1,0 +1,20 @@
+.WorldTextRoot {
+    width: 100%;
+    height: 100%;
+}
+
+.WorldText {
+    text-transform: uppercase;
+    color: gradient( linear, 0% 0%, 100% 0%, from( #F8E8B9), color-stop( 0.5, #E4C269), to( #C79123));
+    text-shadow: 0px 0px 3px 5.0 #000000;
+    font-weight: bold;
+    font-size: 40px;
+    letter-spacing: 2px;
+    margin-left: 5px;
+    font-family: titleFont;
+    transform: rotateX(30deg);
+    background-color: #33333399;
+    border: 4px solid #333333BB;
+    border-radius: 40px;
+    padding: 20px;
+}

--- a/content/panorama/styles/custom_game/world_text.css
+++ b/content/panorama/styles/custom_game/world_text.css
@@ -1,6 +1,7 @@
 .WorldTextRoot {
     width: 100%;
     height: 100%;
+    perspective: 858;
 }
 
 .WorldText {
@@ -8,7 +9,7 @@
     color: gradient( linear, 0% 0%, 100% 0%, from( #F8E8B9), color-stop( 0.5, #E4C269), to( #C79123));
     text-shadow: 0px 0px 3px 5.0 #000000;
     font-weight: bold;
-    font-size: 40px;
+    font-size: 30px;
     letter-spacing: 2px;
     margin-left: 5px;
     font-family: titleFont;

--- a/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
+++ b/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
@@ -188,9 +188,9 @@ function onStart(complete: () => void) {
         waitNpcsSpawned(),
 
         tg.immediate(_ => {
-            worldTexts.add(addWorldText("Modders", Vector(-6700, -4800, 300)))
-            worldTexts.add(addWorldText("Resources", Vector(-5500, -6000, 300)))
-            worldTexts.add(addWorldText("Resources", Vector(-7000, -6500, 400)))
+            worldTexts.add(addWorldText("Modders", Vector(-6700, -4800, 256)))
+            worldTexts.add(addWorldText("Resources", Vector(-5500, -6000, 256)))
+            worldTexts.add(addWorldText("Resources", Vector(-7000, -6500, 384)))
         }),
 
         // Main logic

--- a/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
+++ b/game/scripts/vscripts/Sections/Chapter6/SectionClosing.ts
@@ -5,6 +5,7 @@ import { RequiredState } from "../../Tutorial/RequiredState"
 import { GoalTracker } from "../../Goals"
 import { centerCameraOnHero, Distance2D, getOrError, getPlayerHero, unitIsValidAndAlive } from "../../util"
 import { modifier_closing_npc } from "../../modifiers/modifier_closing_npc"
+import { addWorldText, removeWorldText } from "../../WorldText"
 
 const sectionName: SectionName = SectionName.Chapter6_Closing
 
@@ -142,6 +143,17 @@ const clearNpcs = () => npcs.forEach(npc => npc.destroy())
 
 let sectionTimer: string;
 
+let worldTexts = new Set<number>()
+function clearWorldTexts() {
+    worldTexts.forEach(removeWorldText)
+    worldTexts.clear()
+}
+
+function cleanup() {
+    clearNpcs()
+    clearWorldTexts()
+}
+
 function onStart(complete: () => void) {
     print("Starting", sectionName)
 
@@ -175,6 +187,12 @@ function onStart(complete: () => void) {
         // Hopefully every npc will be spawned by now and this completes immediately
         waitNpcsSpawned(),
 
+        tg.immediate(_ => {
+            worldTexts.add(addWorldText("Modders", Vector(-6700, -4800, 300)))
+            worldTexts.add(addWorldText("Resources", Vector(-5500, -6000, 300)))
+            worldTexts.add(addWorldText("Resources", Vector(-7000, -6500, 400)))
+        }),
+
         // Main logic
         tg.fork([
             // Play dialog
@@ -194,7 +212,7 @@ function onStart(complete: () => void) {
         ]),
 
         // Should never happen currently
-        tg.immediate(_ => clearNpcs()),
+        tg.immediate(_ => cleanup()),
     ]))
 
     graph.start(GameRules.Addon.context, () => {
@@ -221,7 +239,7 @@ function onStop() {
     slacks.RemoveNoDraw()
     sunsFan.RemoveNoDraw()
 
-    clearNpcs()
+    cleanup()
 }
 
 let talkTarget: ClosingNpc | undefined;

--- a/game/scripts/vscripts/WorldText.ts
+++ b/game/scripts/vscripts/WorldText.ts
@@ -1,0 +1,27 @@
+let nextWorldTextIndex = 0;
+
+/**
+ * Adds a text floating in world space.
+ * @param text Text to display.
+ * @param location World-space location to display text at.
+ * @returns Index that can be used with removeWorldText to remove the text again.
+ */
+export function addWorldText(text: string, location: Vector) {
+    CustomGameEventManager.Send_ServerToAllClients("add_world_text", {
+        index: nextWorldTextIndex,
+        text,
+        location: { x: location.x, y: location.y, z: location.z },
+    })
+
+    return nextWorldTextIndex++
+}
+
+/**
+ * Removes a world text.
+ * @param index Index obtained from addWorldText for the text to remove.
+ */
+export function removeWorldText(index: number) {
+    CustomGameEventManager.Send_ServerToAllClients("remove_world_text", {
+        index: index,
+    })
+}


### PR DESCRIPTION
Uses panorama labels and rotateX to make them look flat on the ground.

Still some issues with these
- Overlaps default UI
- Overlaps 3D objects (hero etc.), don't think we can fix that one
- No perspective transform (should be possible to do this slightly better at least, we can scale based on distance for example)

![image](https://user-images.githubusercontent.com/2614101/111717366-d0189d00-884f-11eb-9257-8f6a71a2e2cf.png)
