### PR TITLE
CH2 Tower - What is tower can never die

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter2/shared.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/shared.ts
@@ -12,6 +12,12 @@ export enum LastHitStages {
     LAST_HIT_DENY = 3,
 }
 
+export enum TowerHitSources {
+    NONE = 1,
+    DK_ONLY = 2,
+    ALL = 3
+}
+
 export const radiantCreepsNames = [CustomNpcKeys.RadiantMeleeCreep, CustomNpcKeys.RadiantMeleeCreep, CustomNpcKeys.RadiantMeleeCreep, CustomNpcKeys.RadiantMeleeCreep, CustomNpcKeys.RadiantRangedCreep];
 export const direCreepNames = [CustomNpcKeys.DireMeleeCreep, CustomNpcKeys.DireMeleeCreep, CustomNpcKeys.DireMeleeCreep, CustomNpcKeys.DireMeleeCreep, CustomNpcKeys.DireRangedCreep];
 

--- a/game/scripts/vscripts/modifiers/modifier_nodamage_chapter2_tower.ts
+++ b/game/scripts/vscripts/modifiers/modifier_nodamage_chapter2_tower.ts
@@ -1,12 +1,22 @@
 import { BaseModifier, registerModifier } from "../lib/dota_ts_adapter";
+import { TowerHitSources } from "../Sections/Chapter2/shared";
+import { getPlayerHero } from "../util";
 
 @registerModifier()
 export class modifier_nodamage_chapter2_tower extends BaseModifier {
+    hitSources: TowerHitSources = TowerHitSources.NONE
+
     DeclareFunctions(): ModifierFunction[] {
         return [ModifierFunction.INCOMING_DAMAGE_PERCENTAGE]
     }
 
-    GetModifierIncomingDamage_Percentage(): number {
-        return -100
+    GetModifierIncomingDamage_Percentage(event: ModifierAttackEvent): number {
+        if (this.hitSources === TowerHitSources.NONE) {
+            return -100
+        } else if (this.hitSources === TowerHitSources.DK_ONLY && event.attacker !== getPlayerHero()) {
+            return -100
+        } else {
+            return 0
+        }
     }
 }


### PR DESCRIPTION
CH2 Tower section, and its no-damage modifier, has gotten a small overhaul.
Instead of having small portions when the tower is immune to all damage, the tower now has the modifier throughout the entire section. Using the new enum `TowerHitSources`, we can more easily control when the tower can take damage, and from who.

- Tower begins immune to all damage.
- When the player is expected to attack the tower (and actually deal damage to it), only the hero can deal damage to the tower.
- On the final section, when we're finally destroying the tower, everyone can damage the tower as usual.