### PR TITLE
Ability learn highlights

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
@@ -196,6 +196,9 @@ const stop = () => {
     const hero = getOrError(getPlayerHero())
     hero.SetIdleAcquire(true)
 
+    removeHighlight(getPathToHighlightAbility(0))
+    removeHighlight(getPathToHighlightAbility(1))
+
     if (graph) {
         graph.stop(GameRules.Addon.context)
         graph = undefined

--- a/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionLeveling.ts
@@ -48,8 +48,12 @@ const start = (complete: () => void) => {
                 tg.neverComplete()
             ]),
             tg.seq([
-                tg.immediate(_ => goalLevelDragonTail.start()),
+                tg.immediate(_ => {
+                    goalLevelDragonTail.start()
+                    highlightUiElement(getPathToHighlightAbility(1))
+                }),
                 tg.upgradeAbility(getOrError(hero.FindAbilityByName(abilNameDragonTail), dragonTailNotFoundMsg)),
+                tg.immediate(() => removeHighlight(getPathToHighlightAbility(1)))
             ]),
         ]),
         tg.immediate(_ => goalLevelDragonTail.complete()),
@@ -158,7 +162,9 @@ const start = (complete: () => void) => {
                 tg.immediate(_ => learnAbilityAllowedName = abilNameBreatheFire),
                 tg.immediate(_ => hero.HeroLevelUp(true)),
                 tg.immediate(_ => goalLevelBreatheFire.start()),
+                tg.immediate(_ => highlightUiElement(getPathToHighlightAbility(0))),
                 tg.upgradeAbility(getOrError(hero.FindAbilityByName(abilNameBreatheFire), "Breathe Fire was not found.")),
+                tg.immediate(_ => removeHighlight(getPathToHighlightAbility(0)))
             ])
         ]),
         tg.immediate(_ => goalLevelBreatheFire.complete()),

--- a/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/SectionTower.ts
@@ -298,7 +298,7 @@ const onStart = (complete: () => void) => {
                                 playerHero.AddExperience(levelsToGrant, ModifyXpReason.UNSPECIFIED, false, true)
                                 const dragonFormAbilityHandle = playerHero.FindAbilityByName(elderDragonFormAbility)
                                 if (!dragonFormAbilityHandle) error("Could not find the Elder Dragon Form ability")
-                                dragonFormAbilityHandle.SetUpgradeRecommended(true)
+                                highlightUiElement(getPathToHighlightAbility(3))
                                 ignorePlayerOrders = false
                                 playerMustOrderTrainUltimate = true
                                 playerMustOrderTrainAbilities = true
@@ -316,7 +316,7 @@ const onStart = (complete: () => void) => {
                                 const dragonFormAbilityHandle = playerHero.FindAbilityByName(elderDragonFormAbility)
                                 if (!dragonFormAbilityHandle) error("Could not find the Elder Dragon Form ability")
                                 if (dragonFormAbilityHandle.GetLevel() > 0) {
-                                    dragonFormAbilityHandle.SetUpgradeRecommended(false)
+                                    removeHighlight(getPathToHighlightAbility(3))
                                     playerMustOrderTrainUltimate = false
                                     return true
                                 }
@@ -325,6 +325,9 @@ const onStart = (complete: () => void) => {
                             tg.immediate(() => {
                                 goalTrainUltimate.complete()
                                 goalTrainAbilities.start()
+                                highlightUiElement(getPathToHighlightAbility(0))
+                                highlightUiElement(getPathToHighlightAbility(1))
+                                highlightUiElement(getPathToHighlightAbility(2))
                             }),
                             tg.completeOnCheck(() => {
                                 if (playerHero.GetAbilityPoints() === 0) {
@@ -338,6 +341,9 @@ const onStart = (complete: () => void) => {
                     ]),
                     tg.immediate(() => {
                         goalTrainAbilities.complete()
+                        removeHighlight(getPathToHighlightAbility(0))
+                        removeHighlight(getPathToHighlightAbility(1))
+                        removeHighlight(getPathToHighlightAbility(2))
                     }),
 
                     // Fork use ulti dialogue
@@ -462,6 +468,12 @@ const onStart = (complete: () => void) => {
 
 const onStop = () => {
     print("Stopping", sectionName);
+
+    for (let index = 0; index <= 3; index++) {
+        removeHighlight(getPathToHighlightAbility(index))
+    }
+
+
     removeHighlight(glyphUIPath);
     const context = GameRules.Addon.context
     removeContextEntityIfExists(context, Chapter2SpecificKeys.RadiantCreeps)

--- a/game/scripts/vscripts/TutorialGraph/Steps.ts
+++ b/game/scripts/vscripts/TutorialGraph/Steps.ts
@@ -1,7 +1,7 @@
-import { getCameraDummy, findAllPlayersID, getPlayerHero, setGoalsUI, setUnitVisibilityThroughFogOfWar, createPathParticle, getOrError, HighlightProps, highlight, unitIsValidAndAlive, showPressKeyMessage } from "../util"
 import * as dg from "../Dialog"
-import * as tg from "./Core"
 import { getSoundDuration } from "../Sounds"
+import { createPathParticle, findAllPlayersID, getCameraDummy, getOrError, getPlayerHero, highlight, HighlightProps, setGoalsUI, setUnitVisibilityThroughFogOfWar, showPressKeyMessage, unitIsValidAndAlive } from "../util"
+import * as tg from "./Core"
 
 const isPlayerHeroNearby = (location: Vector, radius: number) => getOrError(getPlayerHero()).GetAbsOrigin().__sub(location).Length2D() < radius
 
@@ -431,11 +431,8 @@ export const upgradeAbility = (ability: tg.StepArgument<CDOTABaseAbility>, minim
         const actualAbility = tg.getArg(ability, context)
         const actualMinimumLevel = tg.getOptionalArg(minimumLevel, context) ?? 1
 
-        actualAbility.SetUpgradeRecommended(true)
-
         const checkAbilityLevel = () => {
             if (actualAbility.GetLevel() >= actualMinimumLevel) {
-                actualAbility.SetUpgradeRecommended(false)
                 complete()
             } else {
                 checkTimer = Timers.CreateTimer(0.1, () => checkAbilityLevel())
@@ -444,9 +441,7 @@ export const upgradeAbility = (ability: tg.StepArgument<CDOTABaseAbility>, minim
         checkAbilityLevel()
     }, context => {
         if (checkTimer) {
-            const actualAbility = tg.getArg(ability, context)
             Timers.RemoveTimer(checkTimer)
-            actualAbility.SetUpgradeRecommended(false)
             checkTimer = undefined
         }
     })


### PR DESCRIPTION
Replaced all `SetUpgradeRecommended` calls with our highlight stuff, which is more noticeable.
Removed `SetUpgradeRecommended` from upgradeAbility steps.

CH1: Added highlight call when the player's expected to learn Dragon Tail.
CH1: Added highlight call when the player's expected to learn Breathe Fire.
CH2: Added highlight call when the player's expected to learn Elder Dragon Form.
CH2: Added highlight call when the player's expected to learn any of the basic abilities.