### PR TITLE
Fix being able to level up Breathe Fire instead of Dragon Tail

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
+++ b/game/scripts/vscripts/Sections/Chapter1/SectionCameraUnlock.ts
@@ -93,7 +93,6 @@ const onStart = (complete: () => void) => {
 
         // Level up and done
         tg.immediate(_ => getOrError(getPlayerHero()).HeroLevelUp(true)),
-        tg.wait(1),
     ]))
 
     graph.start(GameRules.Addon.context, () => {


### PR DESCRIPTION
We level up in the section before the one that has the order filter. Removed the wait so that should make it almost impossible (maybe if you do it frame-perfect?). Could also add the order filter to camera section.