### PR TITLE
Add skip stacking button to Chapter 3

### DIFF
--- a/common/events.d.ts
+++ b/common/events.d.ts
@@ -79,6 +79,10 @@ interface ShowPressKeyMessage {
     text: string // Should contain {key} to show the key
 }
 
+interface ShowChapter3SkipButtonEvent {
+    show: boolean
+}
+
 interface CustomGameEventDeclarations {
     section_started: SectionStartedEvent;
     skip_to_section: SkipToSectionEvent;
@@ -107,4 +111,6 @@ interface CustomGameEventDeclarations {
     remove_world_text: RemoveWorldTextEvent;
     show_press_key_message: ShowPressKeyMessage;
     hide_press_key_message: {};
+    show_chapter3_skip_button: ShowChapter3SkipButtonEvent;
+    skip_chapter3: {}
 }

--- a/content/panorama/layout/custom_game/hud.xml
+++ b/content/panorama/layout/custom_game/hud.xml
@@ -38,6 +38,10 @@
 
         <Label id="PressKeyMessage" />
 
+        <Button id="Chapter3SkipButton" class="ButtonBevel" onactivate="skipChapter3()">
+            <Label text="#Misc_3_SkipStacking" />
+        </Button>
+
         <Panel id="ChaptersMenu" hittest="false">
             <Panel class="ChaptersMenuHeader">
                 <Label class="ChaptersTitle" text="#Chapters" hittest="false"/>

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -236,3 +236,18 @@ function hidePressKeyMessage() {
 
 GameEvents.Subscribe("show_press_key_message", event => showPressKeyMessage(event.command, event.text));
 GameEvents.Subscribe("hide_press_key_message", event => hidePressKeyMessage());
+
+// Chapter 3 skip
+const chapter3SkipButton = $("#Chapter3SkipButton");
+chapter3SkipButton.visible = false;
+
+function skipChapter3() {
+    GameEvents.SendCustomGameEventToServer("skip_chapter3", {});
+    chapter3SkipButton.visible = false;
+}
+
+function onShowSkipChapter3Button(show: boolean) {
+    chapter3SkipButton.visible = show;
+}
+
+GameEvents.Subscribe("show_chapter3_skip_button", event => onShowSkipChapter3Button(event.show !== 0));

--- a/content/panorama/styles/custom_game/hud.css
+++ b/content/panorama/styles/custom_game/hud.css
@@ -592,3 +592,11 @@
     opacity: 1;
     transform: scale3d(1, 1, 1);
 }
+
+#Chapter3SkipButton {
+    vertical-align: center;
+    horizontal-align: right;
+    margin-top: 200px;
+    margin-right: 300px;
+    box-shadow: 0 0 5px gold;
+}

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -115,6 +115,9 @@
 
         "dota_item_build_title_default" "Items for future victim"
 
+        // Misc things for sections
+        "Misc_3_SkipStacking" "Skip stacking"
+
         // Press key messages
         "PressKey_ChatWheel" "Hold {s:key} to open the chat wheel."
         "PressKey_Voice" "Hold {s:key} to speak."


### PR DESCRIPTION
Fixes #416 

- Show skip button during stacking parts
- If you press it once, it will skip all stacking parts of the section

Didn't find a way to break it. Also it still plays all the other stuff of the section such as OD spawning even if you skip the first stacking part but I think that's okay?

![image](https://user-images.githubusercontent.com/2614101/111870898-2f28ff80-897f-11eb-80e1-54700a2cb44f.png)
