### PR TITLE
Fix Courier delivery being ordered too soon breaking courier section

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
+++ b/game/scripts/vscripts/Sections/Chapter2/sectionCourier.ts
@@ -172,19 +172,18 @@ const onStart = (complete: () => void) => {
             playerOrderMustBuyRecipeAndCrystalis = false
         }),
 
-        tg.audioDialog(LocalizationKey.Script_2_Courier_6, LocalizationKey.Script_2_Courier_6, context => context[CustomNpcKeys.SunsFanMudGolem]),
-        tg.audioDialog(LocalizationKey.Script_2_Courier_7, LocalizationKey.Script_2_Courier_7, context => context[CustomNpcKeys.SunsFanMudGolem]),
-
         // Fork dialog mentioning courier delivery button
         tg.forkAny([
             tg.seq([
+                tg.audioDialog(LocalizationKey.Script_2_Courier_6, LocalizationKey.Script_2_Courier_6, context => context[CustomNpcKeys.SunsFanMudGolem]),
+                tg.audioDialog(LocalizationKey.Script_2_Courier_7, LocalizationKey.Script_2_Courier_7, context => context[CustomNpcKeys.SunsFanMudGolem]),
+                tg.immediate(_ => highlightUiElement(deliverItemsUIPath)),
                 tg.audioDialog(LocalizationKey.Script_2_Courier_8, LocalizationKey.Script_2_Courier_8, context => context[CustomNpcKeys.SlacksMudGolem]),
                 tg.audioDialog(LocalizationKey.Script_2_Courier_9, LocalizationKey.Script_2_Courier_9, context => context[CustomNpcKeys.SlacksMudGolem]),
                 tg.neverComplete()
             ]),
             tg.seq([
                 tg.immediate(_ => {
-                    highlightUiElement(deliverItemsUIPath)
                     playerOrderMustDeliverItemsFromCourier = true
                     goalRequestItemsToBeDeliveredFromCourier.start()
                 }),


### PR DESCRIPTION
Fixes a reported issue that caused prematurely ordering the courier to deliver Daedalus components to you would cause the game to get stuck. Visually, this looks the same to the player as before, but prematurely ordering the courier just hurries things along.