### PR TITLE
Fix game not starting on very slow computers or alt-tabbed

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -240,7 +240,7 @@ export class GameMode {
                 this.StartGame();
             };
 
-            Timers.CreateTimer(0.1, tryStart);
+            Timers.CreateTimer(0.1, () => tryStart());
         }
 
         if (state === DOTA_GameState.DOTA_GAMERULES_STATE_GAME_IN_PROGRESS) { }

--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -238,7 +238,7 @@ export class GameMode {
                 }
 
                 this.StartGame();
-            }
+            };
 
             Timers.CreateTimer(0.1, tryStart);
         }

--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -232,7 +232,15 @@ export class GameMode {
             GameRules.SetTimeOfDay(0.5) // Set to day
             this.Game.SetDaynightCycleDisabled(true)
 
-            Timers.CreateTimer(3, () => this.StartGame());
+            const tryStart = () => {
+                if (!getPlayerHero()) {
+                    return 0.1;
+                }
+
+                this.StartGame();
+            }
+
+            Timers.CreateTimer(0.1, tryStart);
         }
 
         if (state === DOTA_GameState.DOTA_GAMERULES_STATE_GAME_IN_PROGRESS) { }


### PR DESCRIPTION
We had a hard-coded 3 second start timer before. Now instead we check for whether the hero is actually spawned.