### PR TITLE
Replace SetAbsOrigin calls with FindClearSpaceForUnit

### DIFF
--- a/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
+++ b/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
@@ -630,7 +630,7 @@ const onStart = (complete: () => void) => {
             tg.immediate((ctx) => {
                 goalMoveToRiki.start()
                 let riki = ctx[CustomNpcKeys.Riki] as CDOTA_BaseNPC
-                riki.SetAbsOrigin(rikiLocation)
+                FindClearSpaceForUnit(riki, rikiLocation, true)
                 let backstab = riki.FindAbilityByName("riki_backstab")
                 backstab!.SetLevel(0)
                 riki.RemoveModifierByName("modifier_invisible")

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -167,6 +167,7 @@ function handleHeroCreationAndLevel(state: FilledRequiredState): CDOTA_BaseNPC_H
     if (state.heroLocation.__sub(hero.GetAbsOrigin()).Length2D() > state.heroLocationTolerance) {
         hero.Stop()
         hero.SetAbsOrigin(state.heroLocation)
+        FindClearSpaceForUnit(hero, state.heroLocation, true)
     }
 
     hero.SetGold(state.heroGold, false)
@@ -354,7 +355,7 @@ function handleRoshan(state: FilledRequiredState) {
 
         if (roshanLocation.__sub(roshan.GetAbsOrigin()).Length2D() > 0) {
             roshan.Stop()
-            roshan.SetAbsOrigin(roshanLocation)
+            FindClearSpaceForUnit(roshan, roshanLocation, true)
         }
 
         roshan.FaceTowards(outsidePitLocation)
@@ -381,7 +382,7 @@ function createOrMoveUnit(unitName: string, team: DotaTeam, location: Vector, fa
 
     const postCreate = (unit: CDOTA_BaseNPC) => {
         if (unit.GetAbsOrigin().__sub(location).Length2D() > 100) {
-            unit.SetAbsOrigin(location)
+            FindClearSpaceForUnit(unit, location, true)
             unit.Stop()
         }
 

--- a/game/scripts/vscripts/Tutorial/SetupState.ts
+++ b/game/scripts/vscripts/Tutorial/SetupState.ts
@@ -166,7 +166,6 @@ function handleHeroCreationAndLevel(state: FilledRequiredState): CDOTA_BaseNPC_H
     // Move the hero if not within tolerance
     if (state.heroLocation.__sub(hero.GetAbsOrigin()).Length2D() > state.heroLocationTolerance) {
         hero.Stop()
-        hero.SetAbsOrigin(state.heroLocation)
         FindClearSpaceForUnit(hero, state.heroLocation, true)
     }
 


### PR DESCRIPTION
Replace setAbsOrigin with FindClearSpaceForUnit to avoid units getting stuck into each other in places where this is possible - when repositioning hero and roshan in `setupState`, and Riki in chapter 3.

Did not use it for the camera dummy since that unit is not obstructable anyway, as well as for the case of TP-ing the player hero back to base

Closes #490