### PR TITLE
Add current chapter label

### DIFF
--- a/content/panorama/layout/custom_game/hud.xml
+++ b/content/panorama/layout/custom_game/hud.xml
@@ -38,6 +38,8 @@
 
         <Label id="PressKeyMessage" />
 
+        <Label id="CurrentChapter" text="#Chapter_1" onmouseover="UIShowTextTooltip('#CurrentChapterTooltip')" onmouseout="UIHideTextTooltip()" />
+
         <Button id="Chapter3SkipButton" class="ButtonBevel" onactivate="showSkipChapter3Confirmation(true)" onmouseover="UIShowTextTooltip('#SkipStackHover')" onmouseout="UIHideTextTooltip()">
             <Label text="#Misc_3_SkipStacking" />
         </Button>

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -296,5 +296,8 @@ GameEvents.Subscribe("show_chapter3_skip_button", event => onShowSkipChapter3But
 
 GameEvents.Subscribe("section_started", event => {
     const chapterName = event.section.split("_")[0];
-    ($("#CurrentChapter") as LabelPanel).text = $.Localize(`#Chapter_${chapterName.substr(chapterName.length - 1)}`);
+    const currentChapterLabel = $("#CurrentChapter") as LabelPanel;
+    currentChapterLabel.text = $.Localize(`#Chapter_${chapterName.substr(chapterName.length - 1)}`);
+    currentChapterLabel.RemoveClass("TextGlow");
+    currentChapterLabel.AddClass("TextGlow");
 });

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -291,3 +291,10 @@ function onShowSkipChapter3Button(show: boolean) {
 }
 
 GameEvents.Subscribe("show_chapter3_skip_button", event => onShowSkipChapter3Button(event.show !== 0));
+
+// Current chapter display
+
+GameEvents.Subscribe("section_started", event => {
+    const chapterName = event.section.split("_")[0];
+    ($("#CurrentChapter") as LabelPanel).text = $.Localize(`#Chapter_${chapterName.substr(chapterName.length - 1)}`);
+});

--- a/content/panorama/scripts/custom_game/hud.ts
+++ b/content/panorama/scripts/custom_game/hud.ts
@@ -297,7 +297,7 @@ GameEvents.Subscribe("show_chapter3_skip_button", event => onShowSkipChapter3But
 GameEvents.Subscribe("section_started", event => {
     const chapterName = event.section.split("_")[0];
     const currentChapterLabel = $("#CurrentChapter") as LabelPanel;
-    currentChapterLabel.text = $.Localize(`#Chapter_${chapterName.substr(chapterName.length - 1)}`);
+    currentChapterLabel.text = $.Localize(`#Chapter_${chapterName.substr(chapterName.length - 1)}`).toLocaleUpperCase();
     currentChapterLabel.RemoveClass("TextGlow");
     currentChapterLabel.AddClass("TextGlow");
 });

--- a/content/panorama/styles/custom_game/hud.css
+++ b/content/panorama/styles/custom_game/hud.css
@@ -696,11 +696,36 @@
     color: gradient( linear, 0% 0%, 100% 0%, from( #F8E8B9 ), color-stop( 0.5, #E4C269), to( #C79123 ) );
     text-shadow: 0px 0px 3px 5.0 #000000;
     font-weight: bold;
-    font-size: 18px;
+    font-size: 22px;
     letter-spacing: 1px;
-    margin-top: 18px;
+    margin-top: 14px;
     margin-left: 238px;
     width: 210px;
     text-overflow: shrink;
     font-family: titleFont;
+}
+
+.TextGlow {
+    animation-name: textGlow;
+    animation-duration: 0.5s;
+    animation-iteration-count: 1;
+    animation-timing-function: linear;
+}
+
+@keyframes 'textGlow' {
+    0% {
+        text-shadow: 0px 0px 3px gold;
+    }
+    25% {
+        text-shadow: 0px 0px 7px gold;
+    }
+    50% {
+        text-shadow: 0px 0px 15px gold;
+    }
+    75% {
+        text-shadow: 0px 0px 7px gold;
+    }
+    100% {
+        text-shadow: 0px 0px 3px gold;
+    }
 }

--- a/content/panorama/styles/custom_game/hud.css
+++ b/content/panorama/styles/custom_game/hud.css
@@ -688,3 +688,19 @@
 #Chapter3SkipConfirmationButtonYes:active {
     sound: "ui_generic_button_click";
 }
+
+#CurrentChapter {
+    text-align: center;
+    align: left top;
+    text-transform: uppercase;
+    color: gradient( linear, 0% 0%, 100% 0%, from( #F8E8B9 ), color-stop( 0.5, #E4C269), to( #C79123 ) );
+    text-shadow: 0px 0px 3px 5.0 #000000;
+    font-weight: bold;
+    font-size: 18px;
+    letter-spacing: 1px;
+    margin-top: 18px;
+    margin-left: 238px;
+    width: 210px;
+    text-overflow: shrink;
+    font-family: titleFont;
+}

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -23,6 +23,7 @@
         "Chapter_5_BriefInformation" "Covers runes, Roshan, and team fights."
         "Chapter_6" "Back Home"
         "Chapter_6_BriefInformation" "Covers attributes. Also features many external resources."
+        "CurrentChapterTooltip" "The chapter you are currently playing."
         "SkipChapter" "Play"
         "Muting_Player" "Muting a Player"
         "Select_Guide" "Selecting a Guide"


### PR DESCRIPTION
Uses the existing section started event. (Assumes that the sections start with the chapter name, eg. Chapter1_Bla to get the chapter nr for localization)

Fixes #525 

![image](https://user-images.githubusercontent.com/2614101/112372714-0cc51800-8cd8-11eb-8228-afc525d97c46.png)
