### PR TITLE
Use file:// instead of s2r:// in css

### DIFF
--- a/content/panorama/layout/custom_game/credits.xml
+++ b/content/panorama/layout/custom_game/credits.xml
@@ -3,7 +3,7 @@
         <include src="file://{resources}/scripts/custom_game/credits.js" />
     </scripts>
     <styles>
-        <include src="s2r://panorama/styles/dotastyles.css" />
+        <include src="s2r://panorama/styles/dotastyles.vcss_c" />
         <include src="s2r://panorama/styles/hudstyles.vcss_c"/>
         <include src="s2r://panorama/styles/hud/hud_reborn.vcss_c" />
         <include src="file://{resources}/styles/custom_game/credits.css" />

--- a/content/panorama/styles/custom_game/custom_loading_screen.css
+++ b/content/panorama/styles/custom_game/custom_loading_screen.css
@@ -1,7 +1,7 @@
 .LoadingScreenRoot {
     width: 100%;
     height: 100%;
-    background-image: url("s2r://panorama/images/leaf_pages/ddb_s1_promo/bg_moon_psd.vtex");
+    background-image: url("file://panorama/images/leaf_pages/ddb_s1_promo/bg_moon_psd.png");
     background-size: 100% 100%;
 }
 
@@ -14,3 +14,4 @@
     margin-top: 20px;
     margin-left: 20px;
 }
+

--- a/content/panorama/styles/custom_game/dialog.css
+++ b/content/panorama/styles/custom_game/dialog.css
@@ -106,7 +106,7 @@
     width: 180px;
     height: 180px;
     transform: translateY(0px) translateX(0px);
-    opacity-mask: url("s2r://panorama/images/masks/killcammask_left_psd.vtex") 1;
+    opacity-mask: url("file://panorama/images/masks/killcammask_left_psd.png") 1;
 }
 
 .AbilityInsetShadowLeft,
@@ -250,7 +250,7 @@
 .CheckMark {
     width: 32px;
     height: 32px;
-    background-image: url("s2r://panorama/images/interface/check_psd.vtex");
+    background-image: url("file://panorama/images/interface/check_psd.png");
     background-position: center;
     background-size: cover;
     background-repeat: no-repeat;
@@ -290,7 +290,7 @@
 }
 
 .WardenNote #JournalPageBackground {
-    background-image: url("s2r://panorama/images/interface/warden_paper_psd.vtex");
+    background-image: url("file://panorama/images/interface/warden_paper_psd.png");
     visibility: visible;
 }
 
@@ -315,7 +315,7 @@
 #JournalPageBackground {
     width: 420px;
     height: 560px;
-    background-image: url("s2r://panorama/images/interface/journal_paper_psd.vtex");
+    background-image: url("file://panorama/images/interface/journal_paper_psd.png");
     background-position: center;
     background-size: cover;
     background-repeat: no-repeat;
@@ -483,7 +483,7 @@
 }
 
 #GlassBallOverlay {
-    background-image: url("s2r://panorama/images/interface/glassoverlay_psd.vtex");
+    background-image: url("file://panorama/images/interface/glassoverlay_psd.png");
     background-position: center;
     background-size: contain;
     background-repeat: no-repeat;
@@ -660,46 +660,46 @@
 #BossIcon {
     height: 48px;
     width: 48px;
-    background-image: url("s2r://panorama/images/interface/minimap_boss_icon_png.vtex");
+    background-image: url("file://panorama/images/interface/minimap_boss_icon_png.png");
     background-size: cover;
     border: 1px solid #444444;
     border-radius: 50%;
 }
 
 #BossIcon.npc_dota_creature_lycan_boss {
-    background-image: url("s2r://panorama/images/interface/boss/lycan_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/lycan_psd.png");
 }
 
 #BossIcon.npc_dota_creature_ogre_tank_boss {
-    background-image: url("s2r://panorama/images/interface/boss/bogdugg_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/bogdugg_psd.png");
 }
 
 #BossIcon.npc_dota_creature_spider_boss {
-    background-image: url("s2r://panorama/images/interface/boss/ankaboot_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/ankaboot_psd.png");
 }
 
 #BossIcon.npc_dota_creature_temple_guardian {
-    background-image: url("s2r://panorama/images/interface/boss/templeguards_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/templeguards_psd.png");
 }
 
 #BossIcon.npc_dota_creature_sand_king {
-    background-image: url("s2r://panorama/images/interface/boss/sandking_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/sandking_psd.png");
 }
 
 #BossIcon.npc_dota_creature_ice_boss {
-    background-image: url("s2r://panorama/images/interface/boss/karaul_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/karaul_psd.png");
 }
 
 #BossIcon.npc_dota_creature_elder_tiny {
-    background-image: url("s2r://panorama/images/interface/boss/storegga_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/storegga_psd.png");
 }
 
 #BossIcon.npc_dota_creature_amoeba_boss {
-    background-image: url("s2r://panorama/images/interface/boss/amoeba_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/amoeba_psd.png");
 }
 
 #BossIcon.npc_dota_creature_siltbreaker {
-    background-image: url("s2r://panorama/images/interface/boss/siltbreaker_psd.vtex");
+    background-image: url("file://panorama/images/interface/boss/siltbreaker_psd.png");
 }
 
 #OverlayMapContainer {
@@ -717,7 +717,7 @@
     transform: translateX(700px) translateY(-310px);
 
     opacity: 1;
-    opacity-mask: url("s2r://panorama/images/masks/softedge_circle_sharper_png.vtex")
+    opacity-mask: url("file://panorama/images/masks/softedge_circle_sharper_png.png")
         1;
     background-color: #000d;
     background-color: gradient(
@@ -760,7 +760,7 @@
         color-stop(0.5, #000d),
         to(#00000000)
     );
-    opacity-mask: url("s2r://panorama/images/masks/softedge_box_png.vtex") 1;
+    opacity-mask: url("file://panorama/images/masks/softedge_box_png.png") 1;
 }
 
 #OverlayMap {
@@ -794,7 +794,7 @@
 .MinimapImage {
     width: 5px;
     height: 5px;
-    background-image: url("s2r://panorama/images/interface/minimap_creep_icon_psd.vtex");
+    background-image: url("file://panorama/images/interface/minimap_creep_icon_psd.png");
     background-position: center;
     background-size: contain;
     wash-color: #0f0;
@@ -808,7 +808,7 @@
 
 .MinimapImage.npc_dota_dungeon_checkpoint,
 .MinimapImage.npc_dota_dungeon_checkpoint.Enemy {
-    background-image: url("s2r://panorama/images/interface/minimap_checkpoint_icon_psd.vtex");
+    background-image: url("file://panorama/images/interface/minimap_checkpoint_icon_psd.png");
     wash-color: #0f0;
     width: 12px;
     height: 12px;
@@ -824,7 +824,7 @@
 }
 
 .MinimapImage.npc_dota_forest_camp_chief {
-    background-image: url("s2r://panorama/images/interface/minimap_camp_chief_icon_psd.vtex");
+    background-image: url("file://panorama/images/interface/minimap_camp_chief_icon_psd.png");
     wash-color: #fff;
     width: 16px;
     height: 16px;
@@ -841,7 +841,7 @@
 .MinimapImage.Boss {
     width: 24px;
     height: 24px;
-    background-image: url("s2r://panorama/images/interface/minimap_boss_icon_png.vtex");
+    background-image: url("file://panorama/images/interface/minimap_boss_icon_png.png");
     background-position: center;
     background-size: contain;
     //background-color: red;
@@ -911,25 +911,25 @@
 }
 
 #Page01 {
-    background-image: url("s2r://panorama/images/comic/01_psd.vtex");
+    background-image: url("file://panorama/images/comic/01_psd.png");
 }
 #Page02 {
-    background-image: url("s2r://panorama/images/comic/02_psd.vtex");
+    background-image: url("file://panorama/images/comic/02_psd.png");
 }
 #Page03 {
-    background-image: url("s2r://panorama/images/comic/03_psd.vtex");
+    background-image: url("file://panorama/images/comic/03_psd.png");
 }
 #Page04 {
-    background-image: url("s2r://panorama/images/comic/04_psd.vtex");
+    background-image: url("file://panorama/images/comic/04_psd.png");
 }
 #Page05 {
-    background-image: url("s2r://panorama/images/comic/05_psd.vtex");
+    background-image: url("file://panorama/images/comic/05_psd.png");
 }
 #Page06 {
-    background-image: url("s2r://panorama/images/comic/06_psd.vtex");
+    background-image: url("file://panorama/images/comic/06_psd.png");
 }
 #Page07 {
-    background-image: url("s2r://panorama/images/comic/07_psd.vtex");
+    background-image: url("file://panorama/images/comic/07_psd.png");
 }
 
 .Page01Visible #Page01,
@@ -1314,7 +1314,7 @@
 #QuestCompleteIcon {
     width: 32px;
     height: 32px;
-    background-image: url("s2r://panorama/images/interface/quest_pip_complete_psd.vtex");
+    background-image: url("file://panorama/images/interface/quest_pip_complete_psd.png");
     background-size: 100%;
     margin-left: -8px;
 }
@@ -1422,11 +1422,11 @@
     margin-right: 2px;
     margin-left: 10px;
     background-size: cover;
-    background-image: url("s2r://panorama/images/hud/reborn/gold_small_psd.vtex");
+    background-image: url("file://panorama/images/hud/reborn/gold_small_psd.png");
 }
 
 #DungeonCompleteXPReward {
-    background-image: url("s2r://panorama/images/interface/xp_icon_psd.vtex");
+    background-image: url("file://panorama/images/interface/xp_icon_psd.png");
 }
 
 #1UpPopup {
@@ -1485,7 +1485,7 @@
 .1upicon {
     width: 64px;
     height: 48px;
-    background-image: url("s2r://panorama/images/interface/1up_psd.vtex");
+    background-image: url("file://panorama/images/interface/1up_psd.png");
     background-position: center;
     background-size: cover;
     horizontal-align: left;
@@ -1493,7 +1493,7 @@
 }
 
 .LifeLost .1upicon {
-    background-image: url("s2r://panorama/images/interface/1down_psd.vtex");
+    background-image: url("file://panorama/images/interface/1down_psd.png");
 }
 
 #BuybackLifeCost {
@@ -1657,7 +1657,7 @@
     overflow: clip scroll;
 
     horizontal-align: center;
-    background-image: url("s2r://panorama/images/hud/reborn/ability_bg_psd.vtex");
+    background-image: url("file://panorama/images/hud/reborn/ability_bg_psd.png");
     background-position: center;
     background-size: cover;
     background-repeat: no-repeat;
@@ -1756,7 +1756,7 @@
 }
 
 #ArtifactCoinIcon {
-    background-image: url("s2r://panorama/images/interface/artifact_coin_psd.vtex");
+    background-image: url("file://panorama/images/interface/artifact_coin_psd.png");
     background-size: 100% 100%;
     width: 20px;
     height: 20px;
@@ -1808,7 +1808,7 @@
     vertical-align: middle;
     margin-bottom: 160px;
     margin-left: 30px;
-    opacity-mask: url("s2r://panorama/images/masks/softedge_circle_sharper_png.vtex")
+    opacity-mask: url("file://panorama/images/masks/softedge_circle_sharper_png.png")
         1;
     opacity: 0;
 

--- a/content/panorama/styles/custom_game/hud.css
+++ b/content/panorama/styles/custom_game/hud.css
@@ -65,7 +65,7 @@
 {
     border: 8px solid    #CFB53B;
     border-radius: 50%;
-    margin-left: -5px;    
+    margin-left: -5px;
 }
 
 #UIHighlightMouseButton {
@@ -692,7 +692,7 @@
 #Chapter3SkipConfirmationButtonNo {
     width: 150px;
     height: 40px;
-    background-image: url("s2r://panorama/images/red_large_off_png.vtex");
+    background-image: url("file://panorama/images/red_large_off_png.png");
     background-repeat: no-repeat;
     background-size: 100% 100%;
     border-top: 1px solid #ffffff05;

--- a/content/panorama/styles/custom_game/team_select.css
+++ b/content/panorama/styles/custom_game/team_select.css
@@ -21,17 +21,17 @@
 {
     width: 430px;
 	height: 100%;
-	flow-children: down;    
+	flow-children: down;
     padding-left: 16px;
 	padding-right: 16px;
     margin-left: 16px;
 }
-    
-#TeamsListGroup 
+
+#TeamsListGroup
 {
     width: 100%;
     vertical-align: center;
-    flow-children: down;    
+    flow-children: down;
 }
 
 #TeamListHeader
@@ -39,7 +39,7 @@
     width: 100%;
     flow-children: right;
 	color: #323232;
-//	border: 2px solid red;	
+//	border: 2px solid red;
     visibility: collapse;
 }
 
@@ -53,7 +53,7 @@
 	margin-left: 8px;
 }
 
-#TeamListLockedIcon 
+#TeamListLockedIcon
 {
     width: 16px;
     height: 16px;
@@ -63,7 +63,7 @@
     wash-color: #aa0000ee;
 }
 
-.teams_locked #TeamListLockedIcon 
+.teams_locked #TeamListLockedIcon
 {
     visibility: visible;
 }
@@ -76,7 +76,7 @@
 }
 
 #ShuffleTeamAssignmentButton
-{    
+{
     height: 32px;
     margin-top: 8px;
     margin-left: 6px;
@@ -133,13 +133,13 @@
     visibility: collapse;
 }
 
-#GameInfoPanel 
+#GameInfoPanel
 {
     margin: 16px;
     flow-children: down;
 }
 
-#GameModeNameLabel 
+#GameModeNameLabel
 {
     font-size: 32px;
 	text-transform: uppercase;
@@ -167,7 +167,7 @@
 	horizontal-align: center;
 }
 
-#StartGameCountdownTimer.countdown_inactive #TeamSelectTimer 
+#StartGameCountdownTimer.countdown_inactive #TeamSelectTimer
 {
     opacity: 0.0;
 }
@@ -188,7 +188,7 @@
     transition-duration: 0.2s;
 }
 
-#TimerLabelBox 
+#TimerLabelBox
 {
 	margin-top: 76px;
     height: 20px;
@@ -206,7 +206,7 @@
     transition-duration: 0.2s;
 }
 
-#StartGameCountdownTimer.auto_start #TimerLabelAutoStart 
+#StartGameCountdownTimer.auto_start #TimerLabelAutoStart
 {
     visibility: visible;
 }
@@ -222,7 +222,7 @@
     transition-duration: 0.2s;
 }
 
-#StartGameCountdownTimer.forced_start #TimerLabelGameStart 
+#StartGameCountdownTimer.forced_start #TimerLabelGameStart
 {
     visibility: visible;
 }
@@ -284,8 +284,8 @@
 }
 
 
-#UnassignedPlayersDivider 
-{	
+#UnassignedPlayersDivider
+{
     width: 100%;
 	height: 2px;
     margin-left: 8px;
@@ -332,8 +332,8 @@
 	color: white;
 }
 
-.unassigned_players #AutoAssignButton:active 
-{    
+.unassigned_players #AutoAssignButton:active
+{
 	sound: "ui_team_select_auto_assign";
 }
 
@@ -351,17 +351,17 @@
 }
 
 #LockAndStartButton
-{ 
+{
     horizontal-align: right;
 	background-color: gradient( linear, 0% 0%, 0% 100%, from( #2d4881cc ), to( #486ca9cc ) );
 	box-shadow: fill #486ca922 -4px -4px 8px 8px;
 	border-top: 1px solid #ffffff03;
-	border-left: 1px solid #ffffff03; 
+	border-left: 1px solid #ffffff03;
     visibility: collapse;
 }
 
 
-.unassigned_players #LockAndStartButton 
+.unassigned_players #LockAndStartButton
 {
     background-color: gradient( linear, 0% 0%, 0% 100%, from( #14161a ), to( #23262b ) );
     box-shadow: fill #00000000 0px 0px 0px 0px;
@@ -369,13 +369,13 @@
     border-left: 1px solid #ffffff03;
 }
 
-#LockAndStartButton Label 
+#LockAndStartButton Label
 {
     transition-property: opacity;
     transition-duration: 0.2s;
 }
 
-.unassigned_players #LockAndStartButton Label 
+.unassigned_players #LockAndStartButton Label
 {
     opacity: 0.1;
 }
@@ -385,8 +385,8 @@
     visibility: visible;
 }
 
-.teams_locked #LockAndStartButton 
-{    
+.teams_locked #LockAndStartButton
+{
     visibility: collapse;
 }
 
@@ -402,17 +402,17 @@
 }
 
 #CancelAndUnlockButton
-{ 
+{
     horizontal-align: right;
     //background-color: gradient( linear, 0% 0%, 0% 100%, from( #722217 ), to( #DD4A29 ) );
 	//box-shadow: fill #DD4A2922 -4px -4px 8px 8px;
 	//border-top: 1px solid #ffffff03;
-	//border-left: 1px solid #ffffff03; 
+	//border-left: 1px solid #ffffff03;
     visibility: collapse;
 
     background-color: gradient( linear, 0% 0%, 0% 100%, from( #2c1b1b ), to( #482e2f ) );
     box-shadow: fill #552e2f00 -4px -4px 8px 9px;
-	
+
 	border-top: 1px solid #3d2929;
 	border-right: 1px solid #372121;
 	border-left: 1px solid #372121;
@@ -448,7 +448,7 @@
     width: 100%;
     margin: 6px;
 	background-color: gradient( linear, 100% 0%, 100% 100%, from( #272b30 ), color-stop( 0.6, #181a1e ), to( #181a1e ) );
-    
+
     //box-shadow: fill #44444430 -5px -5px 9px 9px;
     //border-top: 1px solid #ffffff10;
 	//border-right: 1px solid #000000ff;
@@ -463,7 +463,7 @@
 }
 
 .TeamSelectTeam:hover
-{    
+{
     //background-color: #272b30dd;
 }
 
@@ -474,12 +474,12 @@
 }
 
 .teams_unlocked .TeamSelectTeam:hover #TeamBackgroundGradient
-{    
+{
     visibility: collapse;
 }
 
-#TeamBackgroundGradientHighlight 
-{   
+#TeamBackgroundGradientHighlight
+{
     width: 100%;
     height: 100%;
     visibility: collapse;
@@ -490,7 +490,7 @@
     visibility: visible;
 }
 
-#TeamGroup 
+#TeamGroup
 {
 	background-color: transparent;
     width: 100%;
@@ -510,7 +510,7 @@
 	vertical-align: top;
 	text-shadow: 2px 2px 2px black;
    	margin-left: 1px;
-    margin-top: 1px;    
+    margin-top: 1px;
 	text-transform: uppercase;
 	white-space: nowrap;
 	width: 100%;
@@ -527,7 +527,7 @@
 	vertical-align: center;
 	margin-top: 4px;
     visibility: collapse;
-	
+
 	transition-property: color;
 	transition-duration: 0.2s;
 }
@@ -552,7 +552,7 @@
     opacity: 0;
 }
 
-#TeamPlayerDivider 
+#TeamPlayerDivider
 {
 	width: 100%;
     margin: 2px;
@@ -601,8 +601,8 @@ DOTAAvatarImage
 }
 
 #PlayerIsHostPanel
-{   
-    background-image: url("s2r://panorama/images/icon_star_png.vtex");
+{
+    background-image: url("file://panorama/images/icon_star_png.png");
     background-repeat: no-repeat;
     background-size: contain;
     overflow: noclip;
@@ -630,18 +630,18 @@ DOTAAvatarImage
 	white-space: nowrap;
 }
 
-#PlayerLeaveTeamButton 
+#PlayerLeaveTeamButton
 {
 	width: 24px;
 	height: 24px;
 	wash-color: #aa0000ee;
-	
-	background-image: url("s2r://panorama/images/control_icons/x_close_png.vtex");
+
+	background-image: url("file://panorama/images/control_icons/x_close_png.png");
 	background-size: 24px 24px;
 	background-repeat: no-repeat;
 	background-position: 50% 50%;
 	margin: 4px;
-        
+
     visibility: collapse;
 }
 
@@ -655,7 +655,7 @@ DOTAAvatarImage
     visibility: collapse;
 }
 
-.TeamSelectEmptySlot 
+.TeamSelectEmptySlot
 {
     flow-children: right;
 }
@@ -667,12 +667,12 @@ DOTAAvatarImage
 	font-size: 18px;
 }
 
-#EmptySlotIcon 
-{	
+#EmptySlotIcon
+{
     width: 32px;
 	height: 32px;
     opacity: 0.7;
-    background-image: url("s2r://panorama/images/custom_game/empty_slot_avatar_png.vtex");
+    background-image: url("file://panorama/images/custom_game/empty_slot_avatar_png.png");
     background-size: 32px 32px;
 	background-repeat: no-repeat;
 	background-position: 50% 50%;


### PR DESCRIPTION
New patch seems to have broken `s2r://` in css urls so I replaced them. We also had a wrong extension in an xml for a css file.

Compiled css now seems to be binary so maybe that had something to do with it.