### PR TITLE
Make stacking objectives clearer in CH3

### DIFF
--- a/common/localization.d.ts
+++ b/common/localization.d.ts
@@ -52,6 +52,7 @@ declare const enum LocalizationKey {
     Goal_3_4 = "#Goal_3_4",
     Goal_3_5 = "#Goal_3_5",
     Goal_3_6 = "#Goal_3_6",
+    Goal_3_6_1 = "#Goal_3_6_1",
     Goal_3_7 = "#Goal_3_7",
     Goal_3_8 = "#Goal_3_8",
     Goal_3_9 = "#Goal_3_9",

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -300,6 +300,8 @@
         "Goal_3_4" "Press 'ALT' to see the spawn box."
         "Goal_3_5" "Stack the creeps by attacking them once and running away at XX:53."
         "Goal_3_6" "Try to stack the creeps again, do it successfully at least once"
+        "Goal_3_6" "Stack the creeps at least one more time."
+        "Goal_3_6_1" "Keep trying to stack the creeps. Attempts left"
         "Goal_3_7" "(Optional) Successfully stack the creeps again"
         "Goal_3_8" "Kill the stacked creeps."
         "Goal_3_9" "Pick up the dropped item."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -299,7 +299,6 @@
         "Goal_3_3" "Move to the marked location."
         "Goal_3_4" "Press 'ALT' to see the spawn box."
         "Goal_3_5" "Stack the creeps by attacking them once and running away at XX:53."
-        "Goal_3_6" "Try to stack the creeps again, do it successfully at least once"
         "Goal_3_6" "Stack the creeps at least one more time."
         "Goal_3_6_1" "Keep trying to stack the creeps. Attempts left"
         "Goal_3_7" "(Optional) Successfully stack the creeps again"

--- a/game/scripts/vscripts/Goals.ts
+++ b/game/scripts/vscripts/Goals.ts
@@ -51,7 +51,7 @@ export class TrackableGoalBoolean extends TrackableGoal {
 export class TrackableGoalNumeric extends TrackableGoal {
     private _value: number = 0
 
-    constructor(readonly text: string, readonly maximum: number) {
+    constructor(readonly text: string, readonly maximum?: number) {
         super()
     }
 
@@ -60,7 +60,7 @@ export class TrackableGoalNumeric extends TrackableGoal {
      * @param value Value of the numeric goal.
      */
     setValue(value: number) {
-        if (value < 0 || value > this.maximum) {
+        if (value < 0 || (this.maximum && value > this.maximum)) {
             Warning("Set numeric goal value outside of its range")
         }
 
@@ -77,7 +77,7 @@ export class TrackableGoalNumeric extends TrackableGoal {
     getGoal(): Goal {
         return {
             completed: this.completed,
-            text: this.text + ": " + this._value + "/" + this.maximum
+            text: this.maximum ? this.text + ": " + this._value + "/" + this.maximum : this.text + ": " + this._value
         }
     }
 }
@@ -103,7 +103,7 @@ export class GoalTracker {
      * @param text Text for the goal.
      * @param maximum Maximum number for the goal.
      */
-    addNumeric(text: string, maximum: number): TrackableGoalNumeric {
+    addNumeric(text: string, maximum?: number): TrackableGoalNumeric {
         const state = new TrackableGoalNumeric(text, maximum)
         this.states.push(state)
         return state


### PR DESCRIPTION
- Update numeric goal type so the `maximum` value parameter is optional
- Make stacking objectives clearer by having two separate goals: one for stacking camp once more after ODPixel arrives, and an additional one that instructs you to keep trying while there are still no. of attempts left. Optional goal of successful stacking remains active as before
- Reduce stack try count to 4 to match one of the last dialogue lines

Closes #575 

Todo:
- Maybe split the sexy-tuple stack dialogue line (`Script_3_Opening_25`) into two dialogue lines: one only comments the 6-stack, and the other one talks about ending the section. In that case we would play either `Script_3_Opening_25_1` or the new line at the end of the stacking sequence