### PR TITLE
Rename korean to koreana

### DIFF
--- a/game/resource/addon_koreana.txt
+++ b/game/resource/addon_koreana.txt
@@ -1,6 +1,6 @@
 "lang"
 {
-"Language" "korean"
+"Language" "koreana"
 "Tokens"
 {
 "addon_game_name" "도타 튜토리얼"

--- a/notebooks/ProcessLocalization.ipynb
+++ b/notebooks/ProcessLocalization.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
     "    \"it\": \"italian\",\n",
     "    \"th\": \"thai\",\n",
     "    \"nl\": \"dutch\",\n",
-    "    \"ko\": \"korean\",\n",
+    "    \"ko\": \"koreana\",\n",
     "    \"ro\": \"romanian\",\n",
     "    \"ja\": \"japanese\",\n",
     "    \"cs\": \"czech\",\n",
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Dota uses `koreana` and not `korean` (even though both files are present, the latter is just ignored it seems).