### PR TITLE
Chapter 3-5 location and other minor adjustments

### DIFF
--- a/game/scripts/vscripts/GameMode.ts
+++ b/game/scripts/vscripts/GameMode.ts
@@ -305,6 +305,7 @@ export class GameMode {
                     }
 
                     unit.AddNewModifier(undefined, undefined, modifier_unit_unselectable.name, {})
+                    FindClearSpaceForUnit(unit, unit.GetAbsOrigin().__add(Vector(-450, 0, 0)), true)
                 });
             }
         }

--- a/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
+++ b/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
@@ -16,8 +16,7 @@ const odPixelLocation = Vector(-3635, 5330, 128)
 
 const creepCampMin = Vector(-3776, 4544)
 const creepCampMax = Vector(-2944, 5248)
-const creepCampCenter = creepCampMin.__add(creepCampMax).__mul(0.5)
-
+const smallCampLocation = Vector(-3091, 4756, 128)
 const mediumCampLocation = Vector(-1930, 4520, 384)
 const bigCampLocation = Vector(-4300, 3550, 256)
 const ancientCampLocation = Vector(-4870, -150, 256)
@@ -336,10 +335,10 @@ const onStart = (complete: () => void) => {
                 tg.seq([
                     tg.wait(2),
                     tg.withHighlights(tg.seq([
-                        tg.immediate(_ => AddFOWViewer(DOTATeam_t.DOTA_TEAM_GOODGUYS, creepCampCenter, 600, 6, false)),
-                        tg.panCameraExponential(_ => getPlayerCameraLocation(), creepCampCenter, 2),
+                        tg.immediate(_ => AddFOWViewer(DOTATeam_t.DOTA_TEAM_GOODGUYS, smallCampLocation, 600, 6, false)),
+                        tg.panCameraExponential(_ => getPlayerCameraLocation(), smallCampLocation, 2),
                         tg.wait(2),
-                    ]), { type: "circle", radius: 200, locations: [creepCampCenter] }),
+                    ]), { type: "circle", radius: 200, locations: [smallCampLocation] }),
                     tg.withHighlights(tg.seq([
                         tg.immediate(_ => AddFOWViewer(DOTATeam_t.DOTA_TEAM_GOODGUYS, mediumCampLocation, 600, 6, false)),
                         tg.panCameraExponential(_ => getPlayerCameraLocation(), mediumCampLocation, 2),
@@ -535,11 +534,15 @@ const onStart = (complete: () => void) => {
     ]
 
     const pickUpItems = () => [
-        tg.immediate(_ => DropNeutralItemAtPositionForHero(firstNeutralItemName, creepCampCenter, playerHero, 0, true)),
+        tg.immediate(_ => DropNeutralItemAtPositionForHero(firstNeutralItemName, smallCampLocation, playerHero, 0, true)),
         tg.immediate(_ => goalPickupItem.start()),
-        tg.withHighlights(tg.completeOnCheck(() => playerHero.HasItemInInventory(firstNeutralItemName), 0.1), {
-            type: "arrow",
-            locations: [creepCampCenter],
+        tg.wait(1),
+        tg.withHighlights(tg.completeOnCheck(() => playerHero.HasItemInInventory(firstNeutralItemName), 0.1), _ => {
+            const firstNeutralItem = getOrError(Entities.FindAllByName(firstNeutralItemName)[0] as CDOTA_Item)
+            return {
+                type: "arrow",
+                locations: [firstNeutralItem.GetContainer()!.GetAbsOrigin()],
+            }
         }),
         tg.immediate(_ => {
             highlightUiElement(firstNeutralSlotUIPath)
@@ -572,12 +575,16 @@ const onStart = (complete: () => void) => {
             goalPickUpSecondItem.start()
         }),
 
-        tg.immediate(_ => DropNeutralItemAtPositionForHero(secondNeutralItemName, creepCampCenter, playerHero, 0, true)),
+        tg.immediate(_ => DropNeutralItemAtPositionForHero(secondNeutralItemName, smallCampLocation, playerHero, 0, true)),
+        tg.wait(1),
 
         // Wait for player to pick up item
-        tg.withHighlights(tg.completeOnCheck(() => playerHero.HasItemInInventory(secondNeutralItemName), 0.1), {
-            type: "arrow",
-            locations: [creepCampCenter],
+        tg.withHighlights(tg.completeOnCheck(() => playerHero.HasItemInInventory(secondNeutralItemName), 0.1), _ => {
+            const secondNeutralItem = getOrError(Entities.FindAllByName(secondNeutralItemName)[0] as CDOTA_Item)
+            return {
+                type: "arrow",
+                locations: [secondNeutralItem.GetContainer()!.GetAbsOrigin()],
+            }
         }),
         tg.immediate(_ => goalPickUpSecondItem.complete()),
     ]

--- a/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
+++ b/game/scripts/vscripts/Sections/Chapter3/Chapter3.ts
@@ -16,6 +16,7 @@ const odPixelLocation = Vector(-3635, 5330, 128)
 
 const creepCampMin = Vector(-3776, 4544)
 const creepCampMax = Vector(-2944, 5248)
+
 const smallCampLocation = Vector(-3091, 4756, 128)
 const mediumCampLocation = Vector(-1930, 4520, 384)
 const bigCampLocation = Vector(-4300, 3550, 256)

--- a/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/SectionWards.ts
@@ -24,7 +24,7 @@ const requiredState: RequiredState = {
     topDireT1TowerStanding: false
 };
 
-const markerLocation = Vector(-2467, 3870, 256);
+const markerLocation = Vector(-2800, 3590, 512);
 const wardLocationObs = Vector(-3400, 3800);
 const wardLocationSentry = Vector(-3400, 4000);
 const betweenWardsLocation = (wardLocationObs.__add(wardLocationSentry).__mul(0.5))

--- a/game/scripts/vscripts/Sections/Chapter4/Shared.ts
+++ b/game/scripts/vscripts/Sections/Chapter4/Shared.ts
@@ -5,7 +5,7 @@ export const blockades = {
     direJungleLowgroundRiver: new Blockade(Vector(-4000, 3104, 0), Vector(-3545, 3062, 0)),
     direJungleLowgroundLeft1: new Blockade(Vector(-3921, 3382, 0), Vector(-3917, 4580, 0)),
     direJungleLowgroundTop: new Blockade(Vector(-2656, 4320, 0), Vector(-3744, 4576)),
-    direJungleLowToHighground: new Blockade(Vector(-2468, 4081, 0), Vector(-2783, 3808, 0)),
+    direJungleLowToHighground: new Blockade(Vector(-2592, 4128, 0), Vector(-2805, 3808, 0)),
     direJungleHighgroundTopLeft: new Blockade(Vector(-1540, 4800, 384), Vector(-1190, 5130, 384)),
     direJungleHighgroundTopRight: new Blockade(Vector(-64, 5056, 0), Vector(128, 4480, 0)),
     direJungleHighgroundRight1: new Blockade(Vector(128, 4480, 0), Vector(203, 3604, 0)),

--- a/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
+++ b/game/scripts/vscripts/Sections/Chapter5/SectionRoshan.ts
@@ -45,7 +45,7 @@ function onStart(complete: () => void) {
 
     // DK lvl 25 talents
     const dragonBlood25Talent = playerHero.FindAbilityByName("special_bonus_unique_dragon_knight")
-    const dragonTail25Talent = playerHero.FindAbilityByName("special_bonus_unique_dragon_knight_2")
+    const dragonTailAoe25Talent = playerHero.FindAbilityByName("special_bonus_unique_dragon_knight_8")
 
     graph = tg.withGoals(_ => goalTracker.getGoals(),
         tg.seq([
@@ -74,8 +74,8 @@ function onStart(complete: () => void) {
             // Don't fork since it seems there's no way to prevent a player from upgrading talents, so let the dialogue play out normally - player can skip it if needed
             tg.audioDialog(LocalizationKey.Script_5_Roshan_4, LocalizationKey.Script_5_Roshan_4, ctx => ctx[CustomNpcKeys.SunsFanMudGolem]),
             tg.completeOnCheck(_ => {
-                if (dragonBlood25Talent && dragonTail25Talent)
-                    return ((dragonBlood25Talent.GetLevel() >= 1 || dragonTail25Talent.GetLevel() >= 1))
+                if (dragonBlood25Talent && dragonTailAoe25Talent)
+                    return ((dragonBlood25Talent.GetLevel() >= 1 || dragonTailAoe25Talent.GetLevel() >= 1))
                 else {
                     error("Hero talents/abilities not found!")
                 }


### PR DESCRIPTION
- Update first camp location so small camp creeps are highlighted properly with circle
- Highlight neutral items properly regardless of where they drop
- Update CH4 blockade to prevent player being able to get too much vision on highground by walking up as far as possible
- Move ward marker to new ward spot on hill
- Update talent check in CH5 Roshan section so it completes on last talent select
- Moved courier further left in the fountain so it doesn't potentially confuse the player

Todo:
- Maybe update `Script_4_Wards_8` dialogue line to use the word _ward spot_ or _cliff_ instead of _highground_, though it seems to be ok right now.

Notes:
- The courier position update I added is only called at the beginning of the game, so if someone plays Chapter 2 till the end and skips back to Chapter 1, courier position will reset to it's original position in the center of the fountain